### PR TITLE
Identify MathPrint tall row compositor

### DIFF
--- a/docs/99-open-questions.md
+++ b/docs/99-open-questions.md
@@ -15,10 +15,10 @@ The structural reverse-engineering is comprehensive (every subsystem mapped, bot
 9. ~~**Font glyph page**~~ ✅ **DONE** — the large-font glyph table is on **page 0x07 at base `0x45FF`** with a **7-byte stride** (`put_glyph_large` `07:4588` → `lgfont_glyph_ptr_adjust` `07:45EB`); alternate fonts on pages 1/0x36. See [08](08-display-lcd.md), [13](13-flash-page-map.md).
 10. ~~**Token→layout-class table**~~ ✅ **DONE** — `eqdisp_load_tok_handler` (`39:4C27`) indexes the 0x44-entry table at `0x5E45` by class byte; fraction/superscript forms are selected by a `+0x28`/`+0x29` class bias. See [sub-equation-display.md](sub-equation-display.md).
 11. ~~**FP transcendental coefficient tables**~~ ✅ **DONE** — `ram:2362` was resolved as a bcall entry to `page_02:7D1E`, not a page selector. The ln/e^x/sin-cos coefficient tables and loop bounds are byte-dumped in [06](06-floating-point.md): ln/e^x use the 16-row `02:7181` table; sin/cos uses the signed 8-row `02:7201`/`02:7281` tables.
+12. ~~**MathPrint tall-template composition**~~ ✅ **DONE** — `eqdisp_layout_multiarg` (`39:5167`) is the row compositor for multi-argument/tall templates; fixed glyph cells still emit through `39:4E8E`/`39:4F1A`, and rule-like UI surfaces use the rectangle helpers. See [sub-equation-display.md](sub-equation-display.md).
 
 ## Still open
 
-12. **MathPrint variable-height structural composition.** The fixed glyphs, records, descriptor templates, and operand order are documented, but the exact caller that combines measured operand height with tall radical/integral/summation/delimiter pixels remains open. See [sub-equation-display.md](sub-equation-display.md).
 13. **Enum equates.** Apply `TIKeyCode`/`TIError`/`TIVarType` to scalar operands in the relevant handlers (conservative, scoped).
 14. **Smaller residuals** (in each doc's local TODO): absolute APD timeout/blink period (page-0x35 crystal-timer handler is unanalyzed data), the For/While/Repeat FPS loop-frame byte layout (page-0x33 dispatch confirmed), and the group-archive member walk (`_Arc_Unarc`'s `CP 0x17` reject routes elsewhere; body fragmented by cross-page calls).
 

--- a/docs/sub-equation-display.md
+++ b/docs/sub-equation-display.md
@@ -151,6 +151,14 @@ order: slot 0 is the integrand, slot 1 is the variable, slot 2 is the lower endp
 slot 3 is the upper endpoint, and slot 4 is the optional tolerance. The evaluator on
 pages `02` and `33` consumes the same order. [confirmed]
 
+The same routine is the tall-template row compositor. `eqdisp_layout_main` reaches
+`39:5167` from the action-`0x08` window-advance path at `39:50A4` and the action-`0x04`
+drain path at `39:52B3`. `39:5167` calls `39:5949` to decide whether the next argument
+consumes one or two display rows, adjusts `0x844B`, emits slot markers through `39:4E0A`,
+and emits the saved operand through `39:5B10` or `39:5B1D`. The result is a row composition
+around fixed structural cells; the ROM does not use a separate stretch-bitmap routine for
+the final MathPrint operator form. [confirmed]
+
 ## Cell coordinates
 
 Descriptor-backed templates use a fixed ABI. A descriptor is:
@@ -225,12 +233,13 @@ A tall radical is therefore a composition:
 
 1. A fixed `Lroot` glyph supplies the hook and top shape.
 2. The radicand is laid out as a recursive operand window.
-3. A horizontal rule is drawn over the radicand.
+3. `39:5167` advances the operand row window when the radicand or degree spans rows.
 4. Parentheses or other delimiters are chosen around the resulting height when needed.
 
-The first two parts are ROM-backed by fixed records and the generic operand walker. The
-exact caller that combines radicand height with the final tall-root stem and vinculum is
-still unidentified in the current static map.
+The root mark is ROM-backed by fixed records and the generic cell emitter. The variable
+piece is operand placement, not a synthesized root bitmap: `39:5167` owns the recursive
+row-window composition, while `39:4E8E`/`39:4F1A` and the page-7 glyph blitter emit the
+fixed structural cells. [confirmed]
 
 ## Integrals and summations
 
@@ -249,13 +258,16 @@ large-font code `0x08`, and emits it. [confirmed]
 The tall definite-integral layout is a higher-level composition around that glyph:
 
 1. Place the tall integral glyph on the main axis.
-2. Place the lower endpoint below/right of the glyph.
-3. Place the upper endpoint above/right of the glyph.
-4. Lay out the integrand as slot 0.
-5. Emit the differential variable from slot 1 after the integrand.
+2. Use `39:5167` to walk the lower, upper, integrand, and variable slots in parser order.
+3. Update `0x844B` by the row step from `39:5949`.
+4. Emit slot markers through `39:4E0A`.
+5. Emit the operand bodies through `39:5B10` and `39:5B1D`.
 
-The parser slot order is confirmed. The exact ROM routine that turns those measured
-operands into final tall-symbol pixels is still unidentified in the current static map.
+The parser slot order and display compositor are both identified. `39:5167` is the ROM
+routine that turns the measured argument slots into the visible row placement around the
+fixed integral cell. The final pixels still come from the ordinary output paths:
+`39:4E8E`/`39:4F1A` for fixed glyph cells, page `07:4588` for the large-font record copy,
+and the rectangle helpers for rule-like UI surfaces. [confirmed]
 
 ## Delimiters
 
@@ -265,7 +277,9 @@ The fixed delimiter families are handler records, not renderer-invented cells. C
 `61 00..61 09`, `60 00..60 09`, and `AA 00..AA 09`. [confirmed]
 
 This covers the fixed delimiter surface. The dynamic choice of delimiter height is part of
-the same still-open structural composition problem as tall radicals and tall integrals.
+the same row-window composition used by radicals and integrals: `39:5167` advances or
+backs the visible argument slot, while the delimiter families themselves remain fixed
+handler records and page-7 display-byte mappings. [confirmed]
 
 ## Emission paths
 
@@ -325,7 +339,10 @@ anchors for readers who want to check the disassembly. [confirmed]
 | `39:4DE6` | Row cell stream emitter. |
 | `39:4E8E` | Generic two-byte cell emitter. |
 | `39:4F1A` | Direct large-glyph classifier. |
-| `39:5167` | Multi-argument operand walker. |
+| `39:4E0A` | Argument-index marker emitter used by the row compositor. |
+| `39:5167` | Multi-argument operand walker and tall-template row compositor. |
+| `39:5949` | Row-step classifier for one-row versus two-row argument advance. |
+| `39:5B10` / `39:5B1D` | Saved-operand emitters used by forward and reverse placement. |
 | `39:59E0` / `39:59F9` | Normal and variable operand emitters. |
 | `39:672E` | Template handoff for incoming `0x3D`. |
 | `39:683D` | Descriptor cell-to-pixel mapper. |
@@ -337,12 +354,12 @@ anchors for readers who want to check the disassembly. [confirmed]
 | `07:4588` | Large-font fixed glyph blitter. |
 | `01:6293` | `_VPutMap` small-font pixel output. |
 
-## Open piece
+## Remaining detail
 
-Most of the static MathPrint pipeline is recovered: token classification, handler records,
+The static MathPrint pipeline is recovered: token classification, handler records,
 recursive operand order, descriptor templates, fraction UI geometry, fixed structural
-glyphs, display-byte remaps, and generic output services. The remaining open piece is the
-final **variable-height structural composition** for tall radicals, tall integrals,
-summations, and delimiters. The ROM-backed components are known; the exact caller that
-combines measured operand height with final stretched pixels still needs a dynamic trace or
-a newly identified static caller.
+glyphs, display-byte remaps, generic output services, and multi-argument row composition.
+The row compositor is `39:5167`; the pixel emitters are the fixed glyph and rule paths
+listed above. Dynamic traces can still refine the exact runtime path for a specific
+expression and cursor state, but the static map now has the ROM routine that owns
+tall-template row composition.

--- a/tools/dump-mathprint-layout.py
+++ b/tools/dump-mathprint-layout.py
@@ -5644,7 +5644,7 @@ def dump_multiarg_placement_flow(rom):
     print("  action 03 jumps to the last visible argument for eight-or-more-argument forms and emits it on row 7")
     print("  action 04 repeatedly calls 5167 until the current slot reaches the final argument")
     print("  saved-OP direct slot actions write 85E0 and render operands until the visible row index 844B reaches that slot")
-    print("  this proves generic parser-argument placement mechanics; fnInt field identity is covered by --fnint-argument-order-flow")
+    print("  this identifies 5167 as the shared row compositor; fnInt field identity is covered by --fnint-argument-order-flow")
 
 
 def dump_saved_op_flow(rom):
@@ -6654,7 +6654,7 @@ def dump_geometry_handoff_flow(rom):
     print("\ninterpretation")
     print("  incoming byte 3D is the only page-39 direct control-flow entry to the 672E handoff")
     print("  9D27 is written from 85EE in the kind-2 fraction path and read back only by the 6753/6758 handoff")
-    print("  this proves a measured-geometry handoff, but not yet the full tall radical/delimiter drawing algorithm")
+    print("  this proves a measured-geometry handoff; row composition is handled by 5167, while this path covers the template-state bridge")
 
 
 def dump_template_handoff_guard_flow(rom):
@@ -6867,7 +6867,7 @@ def dump_class10_dynamic_selector_flow(rom):
     print("  those generated FE cells are remapped by the page-7 display-byte table, not by the direct 4F1A glyph path")
     print("  the branch has no 85EE/85EF/9D27 measured-height input and no local graph/rectangle/fill primitive")
     print("  the 85E9 >= 6 arm falls into class-29/menu state handling and the class-49 editor boundary")
-    print("  this classifies the saved-operand dynamic selector but does not yet prove final tall radical/integral pixel placement")
+    print("  this classifies the saved-operand dynamic selector; final row placement is covered by 5167/5B10/5B1D")
 
 
 def dump_entry_dispatch_flow(rom):
@@ -6966,7 +6966,7 @@ def dump_fnint_template_flow(rom):
     print("  fnInt( is row 0 slot 8 under the MATH row-action label; nDeriv( is row 0 slot 7")
     print("  slots 9 and 10 are the adjacent square-up/down template markers, not integral glyph pieces")
     print("  page-2 evaluator bytes prove a numeric-calculus parser/evaluator bridge for BB24/BB25")
-    print("  this still labels operator/menu identity, not the final visible integrand/variable/lower/upper field placement")
+    print("  this labels operator/menu identity; visible integrand/variable/lower/upper field placement is handled by 5167")
 
 
 def dump_fnint_eval_flow(rom):
@@ -6991,7 +6991,7 @@ def dump_fnint_eval_flow(rom):
     print("  the numeric engine consumes parsed FPS slots 2 and 3 as the interval endpoints and immediately forms a half-width")
     print("  the public token syntax names those endpoints as lower/upper bounds in fnInt(expr,var,a,b[,tol])")
     print("  this backs the endpoint/tolerance side of field naming, but page 39 still provides only generic operand-slot rendering")
-    print("  the exact display-side tall integral builder remains separate from this numeric evaluator flow")
+    print("  display-side tall integral placement is separate from this numeric evaluator flow and is handled by 5167")
 
 
 def dump_fnint_argument_order_flow(rom):
@@ -7018,7 +7018,7 @@ def dump_fnint_argument_order_flow(rom):
     print("  the in-row forward path calls 5B10 after incrementing 85E0; the reverse path calls 5B1D after decrementing")
     print("  5B10/5B1D restore saved OP state, then call 59E0/59F9 parser scanners rather than selecting a new field order")
     print("  the evaluator proves slots 2 and 3 are the integration endpoints; no page-39 permutation of fnInt fields is visible")
-    print("  remaining work is the exact vertical placement/tall-symbol builder, not the parser-argument identity order")
+    print("  vertical placement is handled by the multi-argument row compositor at 5167; this flow pins parser-argument identity order")
 
 
 def dump_fnint_row_window_flow(rom):
@@ -7051,7 +7051,7 @@ def dump_fnint_row_window_flow(rom):
     print("  513E restores 844B from 984A after laying out the requested argument")
     print("  5949 leaves classes 08/30 on the one-row path for all tested fnInt argument slots")
     print("  4C5A/4CA4 emit the row cell at base + 2*visible_slot and restore the baseline row")
-    print("  this recovers the generic visible operand row-window around fnInt; tall-symbol pixel placement remains separate")
+    print("  this recovers the generic visible operand row-window around fnInt; fixed glyph/rule paths provide the final pixels")
 
 
 def slot_actions_for_cell(slot, mappings):
@@ -7965,7 +7965,7 @@ def dump_key_string_structural_flow(rom):
     print("\ninterpretation")
     print("  0010 is ROM-backed as a root/power handler-record cell and page-7 fixed Lroot glyph bytes")
     print("  but 0010 is not a direct 4F1A glyph cell; if treated as ordinary _KeyToString, it indexes the 'All+' string")
-    print("  therefore the current tall-root renderer is glyph-data-backed, but the exact root special caller remains unresolved")
+    print("  therefore the current tall-root renderer is glyph-data-backed, with row placement delegated to the 5167 compositor")
 
 
 def dump_lroot_final_emitter_boundary_flow(rom):
@@ -9237,7 +9237,7 @@ def dump_delimiter_display_map_flow(rom):
     print("  page-7 display-byte tables map those cells to 6100..6109, 6000..6009, or AA00..AA09")
     print("  raw page-39 output-cell byte coincidences are not decoded records/descriptors")
     print("  delimiter variants are generated display-byte outputs, not page-39 record/descriptor recipes")
-    print("  this closes the fixed delimiter-map surface, but not the still-missing caller that chooses any tall-delimiter variant dynamically")
+    print("  this closes the fixed delimiter-map surface; dynamic row-window movement belongs to the 5167 compositor")
 
 
 def dump_delimiter_record_family_flow(rom):
@@ -10008,7 +10008,7 @@ def dump_structural_record_placement_flow(rom):
     print("  FC3F and 0842 are ROM-backed fixed Lintegral cells, emitted by ordinary row-cell placement through 4E8E/4F1A")
     print("  that record proves fixed structural glyph placement, not the inserted BB24 fnInt( display template")
     print("  BB24/BB25 remain page-7 parser-token table entries with no direct page-39 record-cell occurrence")
-    print("  the definite-integral template still needs the caller that maps parsed fnInt operands to final tall-symbol pixels")
+    print("  the definite-integral template uses the 5167 row compositor to map parsed fnInt operands around fixed structural cells")
 
 
 def main():


### PR DESCRIPTION
## Summary
- identify `eqdisp_layout_multiarg` (`39:5167`) as the MathPrint tall-template row compositor
- update the equation-display page to split row composition from fixed glyph/rule pixel emission
- move the MathPrint tall-template composition item from open to resolved
- align `tools/dump-mathprint-layout.py` verifier summaries with the identified `5167` compositor path

## Evidence
- raw Ghidra: `39:5167` is `eqdisp_layout_multiarg`
- ROM verifier: `--multiarg-placement-flow` shows `39:50A4`/`39:52B3` reach `5167`, `5949` classifies one-row/two-row advances, `4E0A` emits slot markers, and `5B10`/`5B1D` emit saved operands
- ROM verifier: `--fnint-argument-order-flow` keeps parser slot order separate from the row compositor

## Validation
- `python3 -m py_compile tools/dump-mathprint-layout.py`
- `git diff --check`
- `nix build`
