### PR TITLE
docs: grounding round 2 — matrix re-trace, 2nd/ALPHA state machine, deslop

### DIFF
--- a/docs/04-interrupts.md
+++ b/docs/04-interrupts.md
@@ -39,8 +39,8 @@ Entry saves context (`ex af,af'` / `exx` — the Z80 shadow registers, the class
 | `IY+0x0C` | 3 | `curFlags`·curOn | cursor currently drawn (blink phase) |
 | `IY+0x0C` | 4 | `curFlags`·curAble | cursor-blink enabled |
 | `IY+0x0F` | 7 | `apdFlags`-area | APD sub-state cleared @ `0A8C` on ON-key |
-| `IY+0x12` | 3 | `(IY+0x12)`·"INT/LCD busy" | **reset** first thing in the timer-dispatch tail (`01E0`) — re-entrancy guard |
-| `IY+0x12` | 0 | (same byte) | run-indicator-on flag (set by `_RunIndicOn`) |
+| `IY+0x12` | 3 | `shiftFlags`·shift2nd | the `[2nd]`-pending modifier flag; the ISR clears it at `01E0` (`RES 3`) so a held `[2nd]` does not linger — see the [keyboard modifier state machine](09-keyboard-link.md) |
+| `IY+0x12` | 0 | `indicFlags`·indicRun | run-indicator-on flag (set by `_RunIndicOn`); the byte is shared — bits 0–2 are `indicFlags`, bits 3–7 are `shiftFlags` |
 | `IY+0x16` | 0 | speed/ACK select | chooses the value re-written to int-mask port `0x03` on exit (`00E6`) |
 | `IY+0x16` | 1 | (same byte) | link-busy sub-flag, reset @ `015E` |
 | `IY+0x24` | 2 | link/transfer-active | guards the ON-break vs. link-restore decision (`09EE`, `0AAB`) |

--- a/docs/09-keyboard-link.md
+++ b/docs/09-keyboard-link.md
@@ -42,6 +42,45 @@ The scanner `kbd_scan_autorepeat` (`ram:0406`) walks the matrix one group at a t
 
 **Forming a raw scan code.** For each driven group the routine reads the column byte, then finds the single low (pressed) column bit by an 8-iteration `RLA`/`DJNZ` loop (`0435`–`043C`) that counts set bits into `E` and records the bit index in `L`. If exactly one key is down it builds the scan code as **`(group_index − 1) × 8 + column_index`** (`0453: DEC A; RLA;RLA;RLA; ADD A,L` — the `DEC A` makes the high three bits `group − 1`, then the three `RLA`s shift it up by 8 before adding the column in `L`) and returns it; multiple simultaneous keys set carry (`SCF` @ `0459`) so the press is rejected (debounce / ghost-key reject). The single resulting byte is the raw scan code that lands in `kbdScanCode` (`0x843F`), which `_GetCSC` (`00:04B2`) then reads-and-clears under `DI`. The scan-enable gate `BIT 0,(IY+0x2C)` @ `0415` lets the ISR/`_GetKey` path special-case the arrow group.
 
+### 2nd / ALPHA modifier state machine [confirmed]
+
+While cooking raw scan codes into the `kXxx` key constants, `_GetKey` (`06:491E`) runs a small modifier state machine in **`shiftFlags`** (`IY+0x12` = `0x8A02`, the `[2nd]`/`[ALPHA]` flag byte):
+
+| Bit | Name | Meaning |
+|-----|------|---------|
+| 3 | `shift2nd` | `[2nd]` is pending — the next key is 2nd-shifted |
+| 4 | `shiftAlpha` | alpha mode active — the next key is a letter |
+| 5 | `shiftLwrAlph` | 1 = lowercase, 0 = uppercase |
+| 6 | `shiftALock` | alpha **lock** — alpha survives across keys |
+| 7 | `shiftKeepAlph` | the alpha shift cannot be cancelled |
+
+`_GetKey` first dispatches on the pending modifier (`06:4AC3` `BIT 3` → the 2nd handler at `06:4B87`; `06:4ACA` `BIT 4` → the alpha handler at `06:4BFD`), then on the key. The transitions, with the `SET`/`RES` sites:
+
+- **`[2nd]` (`0x36`) from idle** → `SET shift2nd` (`06:4AD5`); loop without returning a key, lighting the 2nd cursor (`IY+0x1F` bit 6).
+- **`[2nd]` again while pending** → cancel (`06:4B8E` `CP 0x36`, clear the cursor, loop).
+- **any other key while 2nd-pending** → the 2nd handler clears the flag first (`06:4B87` `RES 3`) then returns the **2nd-shifted** code, so `[2nd]` is **one-shot**.
+- **`[ALPHA]` (`0x30`) from idle** → `SET shiftAlpha`, `RES shiftLwrAlph` (uppercase) (`06:4AE8`/`4AEC`); loop, lighting the alpha cursor (`IY+0x1F` bit 7).
+- **`[2nd]` then `[ALPHA]`** (alpha pressed while 2nd is pending) → the 2nd handler reaches `06:4B92` `CP 0x30` and sets `SET shiftALock` + `SET shiftAlpha` (`06:4B96`/`4B9A`): **alpha LOCK**.
+- **`[ALPHA]` while already in alpha** (`06:4BFD`) → in a lowercase-capable context (`IY+0x24` bit 3) and still uppercase, `SET shiftLwrAlph` (`06:4C0D`) cycles **upper → lower**; otherwise it cancels alpha. Repeated `[ALPHA]` walks uppercase → lowercase → off.
+- **`[2nd]` while in alpha** (`06:4C1D`) → `SET shift2nd` (`06:4C25`): a 2nd press stacks on top of alpha (alpha is retained).
+
+`shift2nd` clears the instant a 2nd-combo key is consumed (`06:4B87`). `_GetKey` never clears `shiftAlpha` itself — an un-locked alpha shift persists in `shiftFlags` until a later `[ALPHA]` press cancels it; `shiftALock` (bit 6, from 2nd+ALPHA) is the sticky lock that survives any number of keys.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Second: 2nd, SET b3 @4AD5
+    Second --> Idle: 2nd again, cancel @4B8E
+    Second --> Idle: any key, 2nd-shifted then RES b3 @4B87
+    Second --> AlphaLock: ALPHA, SET b6+b4 @4B96
+    Idle --> Alpha: ALPHA, SET b4 + RES b5 @4AE8
+    Alpha --> Alpha: letter, alpha code, b4 stays
+    Alpha --> AlphaLower: ALPHA, SET b5 @4C0D
+    AlphaLower --> Idle: ALPHA, cancel @4C13
+    AlphaLock --> AlphaLock: letter, alpha code, locked
+    AlphaLock --> Idle: ALPHA, cancel
+```
+
 ### Key → token translation [confirmed]
 
 `_KeyToString` (`01:6D10`) turns a key code into a TI-BASIC **token** for the editor. It's not a single flat table — it combines:

--- a/docs/09-keyboard-link.md
+++ b/docs/09-keyboard-link.md
@@ -40,7 +40,7 @@ The scanner `kbd_scan_autorepeat` (`ram:0406`) walks the matrix one group at a t
 | `0x00` (all low) | "any key down?" probe used by `0x0406`'s initial `SUB A` call; selects all groups |
 | `0xFF` (all high) | release all groups after a read (`kbd_reset_port` writes this at `0491`) |
 
-**Forming a raw scan code.** For each driven group the routine reads the column byte, then finds the single low (pressed) column bit by an 8-iteration `RLA`/`DJNZ` loop (`0435`–`043C`) that counts set bits into `E` and records the bit index in `L`. If exactly one key is down it builds the scan code as **`(group_index − 1) × 8 + column_index`** (`0453: DEC A; RLA;RLA;RLA; ADD A,L` — the `DEC A` makes the high three bits `group − 1`, then the three `RLA`s shift it up by 8 before adding the column in `L`) and returns it; multiple simultaneous keys set carry (`SCF` @ `0459`) so the press is rejected (debounce / ghost-key reject). The single resulting byte is the raw scan code that lands in `kbdScanCode` (`0x843F`), which `_GetCSC` (`00:04B2`) then reads-and-clears under `DI`. The scan-enable gate `BIT 0,(IY+0x2C)` @ `0415` lets the ISR/`_GetKey` path special-case the arrow group.
+**Forming a raw scan code.** For each driven group the routine reads the column byte, then finds the single low (pressed) column bit by an 8-iteration `RLA`/`DJNZ` loop (`0435`–`043C`) that counts set bits into `E` and records the bit index in `L`. If exactly one key is down it builds the scan code as **`group × 8 + column_index`**, where `group` is the 0-based group from the table above. The code forms it at `0453: DEC A; RLA;RLA;RLA; ADD A,L`: the iteration counter in `A` is 1-based, so `DEC A` converts it to the 0-based `group`, the three `RLA`s multiply by 8, and `ADD A,L` adds the column index in `L`; it then returns the byte. multiple simultaneous keys set carry (`SCF` @ `0459`) so the press is rejected (debounce / ghost-key reject). The single resulting byte is the raw scan code that lands in `kbdScanCode` (`0x843F`), which `_GetCSC` (`00:04B2`) then reads-and-clears under `DI`. The scan-enable gate `BIT 0,(IY+0x2C)` @ `0415` lets the ISR/`_GetKey` path special-case the arrow group.
 
 ### 2nd / ALPHA modifier state machine [confirmed]
 
@@ -81,8 +81,10 @@ stateDiagram-v2
     AlphaLower --> Idle: ALPHA, cancel @4C13
     AlphaLock --> AlphaLock: letter, alpha code, locked
     AlphaLock --> Idle: ALPHA, cancel
-    Alpha --> Alpha: 2nd, SET b3 @4C25
-    AlphaLock --> AlphaLock: 2nd, SET b3 @4C25
+    Alpha --> AlphaSecond: 2nd, SET b3 @4C25
+    AlphaLock --> AlphaSecond: 2nd, SET b3 @4C25
+    AlphaSecond --> Alpha: key, 2nd-shifted, RES b3 (b6 clear)
+    AlphaSecond --> AlphaLock: key, 2nd-shifted, RES b3 (b6 set)
 ```
 
 ### Key → token translation [confirmed]

--- a/docs/09-keyboard-link.md
+++ b/docs/09-keyboard-link.md
@@ -54,6 +54,8 @@ While cooking raw scan codes into the `kXxx` key constants, `_GetKey` (`06:491E`
 | 6 | `shiftALock` | alpha **lock** — alpha survives across keys |
 | 7 | `shiftKeepAlph` | the alpha shift cannot be cancelled |
 
+The low three bits of the same `IY+0x12` byte are `indicFlags` (bit 0 `indicRun`, the run/busy indicator set by `_RunIndicOn`; see [04](04-interrupts.md)); `shiftFlags` occupies bits 3–7.
+
 `_GetKey` first dispatches on the pending modifier (`06:4AC3` `BIT 3` → the 2nd handler at `06:4B87`; `06:4ACA` `BIT 4` → the alpha handler at `06:4BFD`), then on the key. The transitions, with the `SET`/`RES` sites:
 
 - **`[2nd]` (`0x36`) from idle** → `SET shift2nd` (`06:4AD5`); loop without returning a key, lighting the 2nd cursor (`IY+0x1F` bit 6).
@@ -64,7 +66,7 @@ While cooking raw scan codes into the `kXxx` key constants, `_GetKey` (`06:491E`
 - **`[ALPHA]` while already in alpha** (`06:4BFD`) → in a lowercase-capable context (`IY+0x24` bit 3) and still uppercase, `SET shiftLwrAlph` (`06:4C0D`) cycles **upper → lower**; otherwise it cancels alpha. Repeated `[ALPHA]` walks uppercase → lowercase → off.
 - **`[2nd]` while in alpha** (`06:4C1D`) → `SET shift2nd` (`06:4C25`): a 2nd press stacks on top of alpha (alpha is retained).
 
-`shift2nd` clears the instant a 2nd-combo key is consumed (`06:4B87`). `_GetKey` never clears `shiftAlpha` itself — an un-locked alpha shift persists in `shiftFlags` until a later `[ALPHA]` press cancels it; `shiftALock` (bit 6, from 2nd+ALPHA) is the sticky lock that survives any number of keys.
+`shift2nd` clears the moment a 2nd-combo key is consumed (`06:4B87`), and the IM1 timer ISR also clears it at `ram:01E0` (`RES 3,(IY+0x12)`), so a pending `[2nd]` does not linger. `_GetKey` sets `shiftAlpha` and (on 2nd+ALPHA) `shiftALock` but reads neither to clear alpha — within `_GetKey`, alpha stays set until a later `[ALPHA]` press cancels it. The one-shot-versus-lock choice is left to the consuming editor, which reads `shiftALock` (bit 6) to decide whether to drop `shiftAlpha` after a single character.
 
 ```mermaid
 stateDiagram-v2
@@ -72,13 +74,15 @@ stateDiagram-v2
     Idle --> Second: 2nd, SET b3 @4AD5
     Second --> Idle: 2nd again, cancel @4B8E
     Second --> Idle: any key, 2nd-shifted then RES b3 @4B87
-    Second --> AlphaLock: ALPHA, SET b6+b4 @4B96
+    Second --> AlphaLock: ALPHA, SET b6 @4B96 + b4 @4B9A
     Idle --> Alpha: ALPHA, SET b4 + RES b5 @4AE8
     Alpha --> Alpha: letter, alpha code, b4 stays
     Alpha --> AlphaLower: ALPHA, SET b5 @4C0D
     AlphaLower --> Idle: ALPHA, cancel @4C13
     AlphaLock --> AlphaLock: letter, alpha code, locked
     AlphaLock --> Idle: ALPHA, cancel
+    Alpha --> Alpha: 2nd, SET b3 @4C25
+    AlphaLock --> AlphaLock: 2nd, SET b3 @4C25
 ```
 
 ### Key → token translation [confirmed]

--- a/docs/sub-link-transfer.md
+++ b/docs/sub-link-transfer.md
@@ -7,10 +7,9 @@ touches: pushing a program/list/etc. to a computer (TI-Connect) or another calcu
 2.5 mm I/O link or the 84+ USB/hardware link-assist. Builds the full stack on top of [doc 09](09-keyboard-link.md)'s byte
 primitives `_SendAByte` (`3C:420D`) and `_RecAByteIO` (`3C:443F`).
 
-All addresses verified by **disassembling the actual Z80** in the Ghidra DB (`/tmp/ti84-link`,
-headless `Disasm.java`). The decompiler mis-renders these routines badly: they pass arguments in
-registers and do their state work with `SET/RES/BIT b,(IY+d)` flag ops that Ghidra shows as bogus
-`*(param+0xNN)` stores. **Trust the disassembly, not the C view, for this subsystem.**
+Addresses here are read from the raw Z80 disassembly. The decompiler mis-renders this subsystem —
+it passes arguments in registers and does its state work with `SET/RES/BIT b,(IY+d)` flag ops that the
+C view shows as bogus `*(param+0xNN)` stores — so the notes follow the disassembly, not the C view.
 
 Page numbers are the masked flash page (`rawpage & 0x3F`). The whole silent-link engine lives on
 **flash page 3C** (shared with the flash/archive command code — see [sub-vat-archive.md](sub-vat-archive.md)).

--- a/docs/sub-matrix-list.md
+++ b/docs/sub-matrix-list.md
@@ -8,8 +8,7 @@ How the TI-84 Plus OS (2.55MP) stores, indexes, and computes on **lists** and
 `SortA(`). Companion to [05-variables-vat.md](05-variables-vat.md) (where the data lives), [06-floating-point.md](06-floating-point.md)
 (how each element is computed), and [sub-vat-archive.md](sub-vat-archive.md) (Store/Recall/Archive).
 
-All `page:addr` verified by **disassembling the Z80** in the private Ghidra copy
-(`/tmp/ti84-matlist`, headless `Dec.java`/`Disasm.java`), not the decompiler alone.
+All `page:addr` are read from the raw Z80 disassembly, not the decompiler alone.
 Page numbers are the masked flash page (`rawpage & 0x3F`). The whole-OS image lives in one
 Ghidra program with address spaces `ram` (the page-0/RAM-resident 0x0000–0x7FFF window) and
 `page_NN` for each flash page mapped into the 0x4000–0x7FFF bank-A window.
@@ -264,30 +263,36 @@ mismatch (`A.cols ≠ B.rows`) ⇒ `_ErrDimMismatch`. Each multiply/add is a ful
 so an `n×n` product is `n³` `_FPMult` + `_FPAdd` calls. [H] (structure inferred; `02:40BA`,
 `02:5FE6`, `02:5766` not defined functions in the live DB)
 
-### Transpose `[A]ᵀ` — driver `02:4178` [C]
-The transpose token (`tTranspose`) routes through the page-02 function evaluator
-(`func_eval_dispatch` family) to **`mat_transpose` @ `02:4178`**: it allocates the result, sets
-the swapped dim into the loop frame (`84B5` from `84B7`), then walks `(i,j)` reading
-`[A](i,j)`→OP1 via `402C`/`47B9` and storing through `_PutToMat` (`4068`), i.e.
-`dst(c,r) = src(r,c)` — a re-indexed column-major copy reusing `_AdrMEle`. It shares the
-element-loop framing with the per-element apply at `412A` (not a defined function in the live
-DB; address unverified) and the row ops (`414E`). [C]
+### Transpose `[A]ᵀ` — body address not confirmed [H]
+The live Ghidra DB names `02:4178` **`mat_fill_type1`**, and its disassembly is a single-counter
+per-cell loop, not a transpose: it sets `84AF=1`, copies one dim into the loop frame (`84B5` from
+`84B7`), then walks **one** counter (`84B5`), reading an element via `402C` (`mele_getOP1_d7`),
+applying an FP op through `47B9`/`479F` (`fp_op2_apply_9d65b`/`fp_op2_apply_9d65`), and storing via
+`4068` (`mele_store_ckvalid`). Decrementing only `84B5` walks the cells with a single index; a true
+transpose needs the swapped read `dst(c,r)=src(r,c)`, which re-indexes **both** `i` and `j`. So
+`02:4178` is a `Fill(`-style per-cell apply, and the earlier `mat_transpose @ 02:4178` mapping is
+not supported by the bytes. The transpose token's real body must be re-traced through the page-02
+command dispatcher; it is unresolved here. `02:4178` shares the element-loop framing with the per-
+element apply at `412A` (not a defined function in the live DB; address unverified) and the row
+ops (`414E`). [H]
 
-### `augment(`, `randM(`, `List►matr(`, `Matr►list(` — per-function drivers [C]
+### `augment(`, `randM(`, `List►matr(`, `Matr►list(` — per-function drivers [H]
 These are dispatched from the page-02 function-token evaluator (the `CP imm ; JR/JP` chain at
-`02:55xx`–`63xx` keyed on the token byte), each with its **own driver** on page 02: [C]
+`02:55xx`–`63xx` keyed on the token byte). The dispatch *sites* below are byte-confirmed call
+sites, but the live Ghidra DB names the called functions for behaviour that does **not** match the
+command claim — so the command→body mapping is downgraded and flagged for re-tracing: [H]
 
-| Token | site (page 02) | driver | what it does |
+| Token | site (page 02) | called fn (live name) | what the disassembly shows |
 |---|---|---|---|
-| `augment(` | `0x91` @ `635B` | **`02:4663`** | type-checks both operands are matrices, `LD A,H ; CP L` rejects a row-count mismatch (`E_Dimension 2719`), then concatenates columns: a partial-pivot-style scan-free copy of `[A]`'s then `[B]`'s columns into a `rows × (colsA+colsB)` result. (`augment(L1,L2)` list-concat is the `0x92` sibling at `637F`.) |
-| `randM(` | `0xB5` @ `62D4` | `02:5264`/`5344` | allocates the `r×c` result and stamps a random `TIFloat` (via `_Random`) into every cell — the matrix `Fill(`-style element loop. |
-| `Matr►list(` | `0x8D` @ `6388` | `02:49E3`/`4773` | column-major copy of matrix columns out into list(s); length-checks via `21BB`. |
-| `List►matr(` | `0x8E` @ `61C1` | `02:7D19` + copy | reshapes the argument lists into a matrix (`_DataSize`-counted float copy `4539`/`453F`). |
+| `augment(` | `0x91` @ `635B` | `02:4663` = **`mat_gauss_engine`** | The `0x91` branch does its own `LD A,H ; CP L ; JP NC,2719` row-count guard and a copy via `6238` (`store_to_var_mem`) before `6379: CALL 0x4663`. But `4663` itself is a **second elimination engine**: it computes `min(H,L)` (`LD A,H ; CP L ; JR C ; LD L,H`, not the square `H==L` guard of `42A6`), inits via `475E`, then iterates pivoting from `BC=0x0101` calling `461C` (max-abs), `41D0` (pivot-column scan), `198D` (compare), permutation swaps (`471C`) and stores (`405E`). That is row-echelon/elimination on a possibly non-square matrix, not a column-concatenation. The `augment(` column-concat copy proper is the `6238` step; `4663`'s role here and the true augment body need re-tracing. (`augment(L1,L2)` list-concat is the `0x92` sibling at `637F`.) |
+| `randM(` | `0xB5` @ `62D4` | `02:5264` = **`cplx_swap_dispatch`** | The `0xB5` (randM) branch at `62D4` routes to `6301/630A → CALL 0x5CEB`, **not** to `5264`. `5264`'s only caller is `62D0`, in the *preceding* `0xBD` branch (a complex-operand path), and `5264` itself only calls `5344` (a 9-byte OP-pair move `8499→84A4`) and `52D3` (`cplx_norm_pair`) — complex-number arrangement, not a random-fill over cells. The randM cell-fill body is not `5264`; it sits behind the `0xB5` branch's `5CEB` call and needs re-tracing. |
+| `Matr►list(` | `0x8D` @ `6388` | `02:49E3` = **`lele_copy_until_eq`** | The `0x8D` branch reaches `6397: CALL 0x49E3`. `49E3` is a **list**-element copy loop: it recalls a source element (`47E6`), stores it (`4825`), then compares the running index against a length at `(84AF)` via `21BB` and `RET Z` when equal, else `INC HL` and continues (`1599`). It is a list↔list copy-until-length-match, consistent with the live name. Whether it is the whole `Matr►list(` body (one column of the source matrix extracted into a list) or just its inner per-list copy step needs re-tracing; length-checks still go via `21BB`. |
+| `List►matr(` | `0x8E` @ `61C1` | `02:7D19` + copy | reshapes the argument lists into a matrix (`_DataSize`-counted float copy `4539`/`453F`). [H] |
 
 The shared element-loop kernels these drivers call are the per-element apply at `02:412A` (not a
-defined function in the live DB; address unverified [H]), `mat_row_op` (`02:414E`) and
-`mat_transpose` (`02:4178`) family; the per-function drivers above are now byte-pinned at their
-evaluator entries. [C]
+defined function in the live DB; address unverified [H]) and `mrow_swap_loop` (`02:414E`). The
+dispatch *sites* (`6379`, `62D0`, `6397`) are byte-confirmed; the command→body *behaviour* mapping
+is not, and is flagged for re-tracing through the page-02 dispatcher. [H]
 
 ---
 
@@ -328,15 +333,20 @@ matrix_gauss_engine(A = mode flags):
         BIT 6,A ; JP Z, 0x26F0 (_ErrSingularMat, E_SingularMat 0x83)
         -> inverse (flag 0, bit6=0) ERRORS;  det (flag 0x40, bit6=1) returns 0
 ```
-Key sub-routines (all `page_02`): [C]
-- **`461C`** — compute the matrix's **max-abs element** (numeric scale for the near-zero pivot
-  test).
-- **`41C1`** — `|OP1|` vs `|pivot|` compare (`_AbsO1O2Cp`); **`41D0`** — scan a column for the
-  **largest-magnitude pivot** (partial pivoting), calling `43B9` to swap rows as it goes.
-- **`43B9` / `414E` / `_AdrMRow`** — physical **row swap / row scale** (whole-row moves).
+Key sub-routines (all `page_02`; names are the live Ghidra DB labels): [C]
+- **`461C` `mat_max_abs`** — compute the matrix's **max-abs element** (numeric scale for the
+  near-zero pivot test).
+- **`41C1` `abs_cmp_op1op2`** — `|OP1|` vs `|pivot|` compare (`1A0F`/`1987` abs+compare);
+  **`41D0`** — scan a column for the **largest-magnitude pivot** (partial pivoting), calling
+  `43B9` to swap rows as it goes.
+- **`43B9` / `414E` `mrow_swap_loop` / `_AdrMRow`** — physical **row swap / row scale**
+  (whole-row moves; `414E` loads the `dim0` stride and swaps two whole rows via `_AdrMRow`×2 +
+  `1DDA`).
 - **`4259`** — swap two entries in the **permutation vector** at `84D5`.
-- **`4473`** — the elimination element step (`[M](i,k) − factor*[M](pivot,k)` via `_FPSub`).
-- **`426D` / `426F`** — row dot-product / back-substitution accumulate (`_FPMult` + `RST6`).
+- **`4473` `ele_sub_ref`** — the elimination element step (`[M](i,k) − factor*[M](pivot,k)`:
+  `RST8 ; CALL 403C ; JP 2297` = load + `_FPSub`).
+- **`426D` `col_dot_accum` / `426F` `col_dot_accum_from`** — column dot-product / back-
+  substitution accumulate (`_FPMult` + `RST6`).
 - Pivot normalize uses **`_FPRecip`** / **`_FPDiv`**; sign/inverse use `_InvOP1S`.
 
 **`det(`** therefore = forward elimination with partial pivoting, **return the signed product
@@ -443,17 +453,17 @@ and the routine and condition that triggers it.
 | `02:40BA` | Ghidra auto-name (retired) | not a defined function in the current Ghidra DB; was an earlier-pass auto-name with no WikiTI/inc backing (`0x40BA` in ti83plus.inc is the unrelated `_SinCosRad` bcall ID). Inferred matrix-multiply body; address unverified (§4) |
 | `02:4108` | `identity_build` | `identity(n)`: diagonal-1 fill (token 0xB4) [C] |
 | `02:412A` | (undisassembled) | per-element matrix unary/binary apply; not a defined function in the current Ghidra DB, structure inferred, address unverified [H] |
-| `02:414E` | `mat_row_op` | row swap/scale (elimination) [C] |
-| `02:4178` | `mat_transpose` | `[A]ᵀ`: `dst(c,r)=src(r,c)` re-indexed copy [C] |
-| `02:4663` | `mat_augment` | `augment(` column-concat (rows must match) [C] |
-| `02:5264` | `mat_randm` | `randM(` random-fill driver [C] |
-| `02:49E3` | `matr_to_list` | `Matr►list(` column→list copy [C] |
-| `02:41C1` | `pivot_abs_cmp` | absolute-value compare: OP1 vs pivot [C] |
+| `02:414E` | `mrow_swap_loop` | row swap/scale (elimination) [C] |
+| `02:4178` | `mat_fill_type1` | live DB name; single-counter per-cell fill/apply loop — **not** transpose. Transpose body unresolved (§4) [H] |
+| `02:4663` | `mat_gauss_engine` | live DB name; `min(H,L)` non-square elimination engine called from the `augment(` `0x91` branch (`6379`) — **not** a column-concat. augment body needs re-tracing (§4) [H] |
+| `02:5264` | `cplx_swap_dispatch` | live DB name; complex OP-pair arrange/swap (`5344`/`52D3`) reached from the `0xBD` branch (`62D0`) — **not** `randM(` random-fill. randM body needs re-tracing (§4) [H] |
+| `02:49E3` | `lele_copy_until_eq` | live DB name; list-element copy-until-length-match (`21BB`, `RET Z`) called from the `Matr►list(` `0x8D` branch (`6397`) — exact command-body extent needs re-tracing (§4) [H] |
+| `02:41C1` | `abs_cmp_op1op2` | absolute-value compare: OP1 vs pivot [C] |
 | `02:41D0` | `pivot_col_scan` | partial-pivot: find largest absolute value in column [C] |
 | `02:4259` | `perm_swap` | swap two entries of the permutation vector (84D5) [C] |
-| `02:426D`/`426F` | `row_dot_accum` | dot-product / back-substitution accumulate [C] |
-| `02:42A6` | `matrix_gauss_engine` | **inverse(flag 0)/det(flag 0x40)** Gauss-Jordan + partial pivot [C] |
-| `02:4473` | `elim_sub_step` | `[M] − factor*pivot` element step (`_FPSub`) [C] |
+| `02:426D`/`426F` | `col_dot_accum`/`col_dot_accum_from` | column dot-product / back-substitution accumulate [C] |
+| `02:42A6` | `matrix_gauss_engine` | **inverse(flag 0)/det(flag 0x40)** Gauss-Jordan + partial pivot; square-only (`H==L` guard) [C] |
+| `02:4473` | `ele_sub_ref` | `[M] − factor*pivot` element step (`_FPSub`) [C] |
 | `02:461C` | `mat_max_abs` | maximum absolute element (pivot tolerance) [C] |
 | `02:47C5` | `_AdrLEle` | list element address: `data+2+(i-1)*9` [C] |
 | `02:47EA` | `_GetLToOP1` | list[i] → OP1 (complex-aware) [C] |
@@ -468,7 +478,7 @@ and the routine and condition that triggers it.
 | `02:5FC0` | `det_entry` | `det(`: flag 0x40 → `matrix_gauss_engine` [C] |
 | `02:6104` | `list_fold_dispatch` | `sum(`/`prod(` higher-order list fold [C] |
 | `02:69B7` | `chk_op_is_matrix` | require operand type==2 else E_DataType [C] |
-| `ram:21C4` | `classify_elem_width` | real-vs-complex (0x0C) element width [C] |
+| `ram:21C4` | `chk_type_lt_1a` | classify element type width: `AND 0x1F ; CP 0x1A ; CP 0x18 ; CCF` — real-vs-complex (0x0C) element width [C] |
 | `35:79E9` | `_ListIdxTimes9` | list index ×9 + dispatch [C] |
 | `07:4D3B` | `_RedimMat` | re-dimension matrix/list [C] |
 | `07:4F07` | `_InsertList`/`_IncLstSize` | grow a list in place [C] |
@@ -493,8 +503,21 @@ and the routine and condition that triggers it.
   the magnitude is the `238B`/`RST 30h` diagonal-pivot accumulate (`43E3–43F6`); `420F`/`4259`
   undo the column permutation for the inverse (§5). Row/col vs dim0/dim1 is now **[C]**:
   `dim0` (first header byte) = #rows, and `_AdrMEle` takes `B=column`, `C=row` (§1/§2).
-- **RESOLVED — per-function matrix drivers.** `augment(`→`02:4663`, `randM(`→`02:5264`,
-  `Matr►list(`→`02:49E3`, `List►matr(`→`02:7D19`, transpose `[A]ᵀ`→`02:4178` (§4).
+- **OPEN — per-function matrix driver bodies need re-tracing.** The page-02 dispatch *sites* are
+  byte-confirmed, but the called functions the live Ghidra DB names there do **not** match the
+  command claims, so these command→body mappings are downgraded to [H] (§4):
+  - `augment(` `0x91` branch (`6379`) calls `02:4663` = `mat_gauss_engine` — a `min(H,L)` non-
+    square **elimination** engine, not a column-concat. The concat copy is the branch's `6238`
+    step; the true augment body is unresolved.
+  - `randM(` `0xB5` branch routes to `5CEB`, not to `02:5264` = `cplx_swap_dispatch` (a complex
+    OP-pair swap reached from the `0xBD` branch at `62D0`). The randM cell-fill body is unresolved.
+  - `Matr►list(` `0x8D` branch (`6397`) calls `02:49E3` = `lele_copy_until_eq`, a list-element
+    copy-until-length-match; whether that is the whole command body or just its inner copy step is
+    unresolved.
+  - transpose `[A]ᵀ`: `02:4178` is `mat_fill_type1` (a single-counter per-cell fill/apply), not a
+    transpose; the transpose body is unresolved.
+  - `List►matr(` `0x8E` branch (`61C1`) → `02:7D19` + `_DataSize` copy (`4539`/`453F`) is
+    unchanged [H].
 - `seq(`/`SortA(`/`SortD(`/stats list-builders: confirm the collect-then-`_CreateRList` loop
   and the in-place float sort/compare. (Residual — comparator `_CpOP1OP2` confirmed; the
   unanalyzed page-02 sort body's element-load is still not byte-traced.)

--- a/docs/sub-matrix-list.md
+++ b/docs/sub-matrix-list.md
@@ -226,17 +226,17 @@ sort body's element-load is not byte-traced]
   ```
   _OP1Set1 ; for each (i,j): if i==j -> store 1.0 (mantissa[0]=0x10) else 0
   ```
-- **`Fill(value,[M])`** / **`randM(`** stamp a constant / random values across all cells
-  (a per-element loop over the whole matrix applies the op at `02:412A`, which is not a
-  defined function in the current Ghidra DB; address unverified). [H]
+- **`Fill(value,[M])`** / **`randM(`** stamp a constant / random values across all cells via a
+  per-cell loop over the whole matrix. `randM(` builds the result through the `0xB5` dispatcher
+  branch (`02:62D4`); its per-cell fill body is the one residual still open (§4). [H]
 - Matrix **copy/reshape** = `_DataSize`-counted byte copy of the float payload
   (`mele_copy9_d3` (`02:4539`)/`mele_copy9_loop` (`02:453F`)). [C]
 
 ### `[A] + [B]`, `[A] - [B]`, scalar·[A] — element-wise [H]
-The **per-element matrix apply** at `02:412A` is a nested `for col { for row { load [M](r,c)→OP1;
-op; store } }` driving the FP RSTs. Binary matrix add/sub require equal dims
-(`_ErrDimMismatch 0x8B`). `02:412A` is not a defined function in the current Ghidra DB; the
-element-loop structure is inferred and the address is unverified.
+Binary matrix add/sub apply the FP op per cell with a nested `for col { for row { load [M](r,c)→OP1;
+op; store } }` walk and require equal dims (`_ErrDimMismatch 0x8B`). The nested two-counter cell
+walk at `02:412A` is the **transpose** copy (§ transpose); the add/sub element-loop driver is a
+sibling in the same `412A`–`414E` family and is inferred here. [H]
 
 ### `[A] * [B]` — matrix multiply [H]
 The matrix-multiply body is not a defined function in the current Ghidra DB; the O(n³) structure
@@ -263,36 +263,51 @@ mismatch (`A.cols ≠ B.rows`) ⇒ `_ErrDimMismatch`. Each multiply/add is a ful
 so an `n×n` product is `n³` `_FPMult` + `_FPAdd` calls. [H] (structure inferred; `02:40BA`,
 `02:5FE6`, `02:5766` not defined functions in the live DB)
 
-### Transpose `[A]ᵀ` — body address not confirmed [H]
-The live Ghidra DB names `02:4178` **`mat_fill_type1`**, and its disassembly is a single-counter
-per-cell loop, not a transpose: it sets `84AF=1`, copies one dim into the loop frame (`84B5` from
-`84B7`), then walks **one** counter (`84B5`), reading an element via `402C` (`mele_getOP1_d7`),
-applying an FP op through `47B9`/`479F` (`fp_op2_apply_9d65b`/`fp_op2_apply_9d65`), and storing via
-`4068` (`mele_store_ckvalid`). Decrementing only `84B5` walks the cells with a single index; a true
-transpose needs the swapped read `dst(c,r)=src(r,c)`, which re-indexes **both** `i` and `j`. So
-`02:4178` is a `Fill(`-style per-cell apply, and the earlier `mat_transpose @ 02:4178` mapping is
-not supported by the bytes. The transpose token's real body must be re-traced through the page-02
-command dispatcher; it is unresolved here. `02:4178` shares the element-loop framing with the per-
-element apply at `412A` (not a defined function in the live DB; address unverified) and the row
-ops (`414E`). [H]
+### Transpose `[A]ᵀ` — `02:412A`, dispatched from the `ᵀ` token `0x0E` [C]
+The transpose operator `ᵀ` is the postfix token **`tTrnspos` = `0x0E`**. The page-02 command
+dispatcher handles it at **`02:60E9`** (`CP 0x0E`): it requires one matrix operand (`CP 0x02 ;
+JR NZ`), **swaps the two dimension bytes** for the result header (`60F5: LD A,H ; LD H,L ; LD L,A`),
+allocates the transposed-shape matrix (`5DBB`/`5DE0`), runs the per-cell copy body at **`02:412A`**,
+then stores via `JP 0x5F89`. `02:412A` has exactly one caller, `02:60FE` (byte-verified `CD 2A 41`).
 
-### `augment(`, `randM(`, `List►matr(`, `Matr►list(` — per-function drivers [H]
-These are dispatched from the page-02 function-token evaluator (the `CP imm ; JR/JP` chain at
-`02:55xx`–`63xx` keyed on the token byte). The dispatch *sites* below are byte-confirmed call
-sites, but the live Ghidra DB names the called functions for behaviour that does **not** match the
-command claim — so the command→body mapping is downgraded and flagged for re-tracing: [H]
+**`02:412A` is the transpose copy** [C]. It walks every source cell and writes the value into the
+destination whose `_AdrMEle` stride is the *swapped* dimension, so `dst(c,r) = src(r,c)`:
+```z80
+412A: LD HL,(84AF)              ; loop counters = dims
+412E: CALL 403C                 ; load src [M] (B=col,C=row) from (84D3) → OP1
+4131: LD HL,(84AF) ; LD B,L ; LD C,H
+4136: CALL 4068                 ; store OP1 → dst [M] via dest ptr (84D7)
+4139: DEC (84AF) ; JR NZ,412E   ; inner counter
+4141: LD (HL),C ; INC HL ; DEC (HL) ; JR NZ,412E  ; outer counter
+4146: POP HL ; LD B,L ; LD C,H ; RET
+```
+`403C` reads from the source data pointer `(84D3)`; `4068` writes to the destination pointer
+`(84D7)`. Because the destination header carries the dims swapped (the `60F5` swap), `_AdrMEle`
+(`4002`) computes the column-major offset with the row/column roles exchanged, so the same linear
+walk lands element `src(r,c)` at `dst(c,r)` — a true transpose, which re-indexes **both** `i` and
+`j`. [C]
 
-| Token | site (page 02) | called fn (live name) | what the disassembly shows |
+`02:4178` (`mat_fill_type1`) is a separate single-counter fill/apply in the `414A`–`4178` block,
+not the transpose body. [C]
+
+### `augment(`, `randM(`, `List►matr(`, `Matr►list(` — per-function drivers [C/H]
+These are dispatched from the page-02 function-token evaluator (`list_fold_dispatch`, the
+`CP imm ; JR/JP` chain that runs `5E46`/`60C8`–`63xx`, keyed on the token byte). Each command's
+body and its single caller are byte-verified below.
+
+| Command | dispatch site | body | what the disassembly shows |
 |---|---|---|---|
-| `augment(` | `0x91` @ `635B` | `02:4663` = **`mat_gauss_engine`** | The `0x91` branch does its own `LD A,H ; CP L ; JP NC,2719` row-count guard and a copy via `6238` (`store_to_var_mem`) before `6379: CALL 0x4663`. But `4663` itself is a **second elimination engine**: it computes `min(H,L)` (`LD A,H ; CP L ; JR C ; LD L,H`, not the square `H==L` guard of `42A6`), inits via `475E`, then iterates pivoting from `BC=0x0101` calling `461C` (max-abs), `41D0` (pivot-column scan), `198D` (compare), permutation swaps (`471C`) and stores (`405E`). That is row-echelon/elimination on a possibly non-square matrix, not a column-concatenation. The `augment(` column-concat copy proper is the `6238` step; `4663`'s role here and the true augment body need re-tracing. (`augment(L1,L2)` list-concat is the `0x92` sibling at `637F`.) |
-| `randM(` | `0xB5` @ `62D4` | `02:5264` = **`cplx_swap_dispatch`** | The `0xB5` (randM) branch at `62D4` routes to `6301/630A → CALL 0x5CEB`, **not** to `5264`. `5264`'s only caller is `62D0`, in the *preceding* `0xBD` branch (a complex-operand path), and `5264` itself only calls `5344` (a 9-byte OP-pair move `8499→84A4`) and `52D3` (`cplx_norm_pair`) — complex-number arrangement, not a random-fill over cells. The randM cell-fill body is not `5264`; it sits behind the `0xB5` branch's `5CEB` call and needs re-tracing. |
-| `Matr►list(` | `0x8D` @ `6388` | `02:49E3` = **`lele_copy_until_eq`** | The `0x8D` branch reaches `6397: CALL 0x49E3`. `49E3` is a **list**-element copy loop: it recalls a source element (`47E6`), stores it (`4825`), then compares the running index against a length at `(84AF)` via `21BB` and `RET Z` when equal, else `INC HL` and continues (`1599`). It is a list↔list copy-until-length-match, consistent with the live name. Whether it is the whole `Matr►list(` body (one column of the source matrix extracted into a list) or just its inner per-list copy step needs re-tracing; length-checks still go via `21BB`. |
+| `Matr►list(` | `0x8D` @ `6388` | **`02:4773`** (2-arg), `02:49E3` (1-arg list copy) | [C] The `0x8D` branch splits on argument count (`638D: CP 0x02`). The **column-extract engine is `02:4773`** (2-arg path: `639D: CALL 5DD8 ; CALL 4773`; only caller `63A0`, byte-verified `CD 73 47`): it nests a per-row loop (`477B: LD B,1 …`, reading via `4040` `_AdrMRow`/`4068` `mele_store_ckvalid`) inside a column loop over `(84AF)`, copying matrix columns into list element(s) (`4051`/`479F`). The 1-arg/list path uses `02:49E3` (`6397: CALL 0x49E3`), a list-element copy-until-length-match (`47E6` recall, `4825` store, `21BB` compare vs `(84AF)`, `RET Z`). |
+| transpose `ᵀ` | `0x0E` @ `60E9` | **`02:412A`** | [C] Swaps the dim header (`60F5`), allocates the transposed shape, then `412A` copies `dst(c,r)=src(r,c)` over every cell (`403C` read from `(84D3)`, `4068` write to `(84D7)`); only caller `60FE`. See the transpose subsection above. |
+| `augment(` | `0x91` @ `635B` | **`02:6238` copy** [C]; `02:4663` engine [H] | The `0x91` branch requires two operands (`CP 0x02`), reads the dims (`5D98`), and applies an equal-rows guard `LD A,H ; CP L ; JR Z ; JP NC,2719` (`E_Dimension` when the row counts differ). It then runs the **column-concatenation copy at `02:6238`** [C]: `6238` allocates the result (`5DE0` → `5DE6` → `_CreateRMat 110F`) and bulk-copies the float payload with `02:4539` (`mele_copy9_d3` — skip the 2 dim bytes, `LDIR` the column-major data), re-pointing `84D3←84D7`. The branch then calls `02:4663` (`6379`, only caller; byte-verified `CD 63 46`), a partial-pivoting elimination engine: it computes `min(H,L)` (`4672: LD A,H ; CP L ; JR C ; LD L,H`), inits via `475E`, and iterates from `BC=0x0101` calling `461C` (max-abs), `41D0` (pivot-column scan), `198D` (compare), `471C` (permutation swap) and `405E` (store). The column-concat copy (`6238`/`4539`) is confirmed augment behaviour [C]; `4663`'s elimination pass on the concatenated result is byte-confirmed but its role for plain `augment(` is left open [H]. (`augment(L1,L2)` list-concat is the `0x92` sibling at `637F`, sharing the `6362` setup.) |
+| `randM(` | `0xB5` @ `62D4` | create + dim setup (`5DBB`/`5DEB`); cell-fill body open [H] | The `0xB5` branch splits on argument count (`62D9: CP 0x02`): the 2-arg `randM(rows,cols)` path (`62DD`) and the 1-arg square path (`630A`). Both **create the result and set its dims** through `02:5DBB` (`CALL 5CEB` registers the variable by name, stores the data pointer to `84D3`, reads and zero-rejects the dim bytes `OR L ; JP Z,2719`, stores dims to `84AF`) and `02:5DEB`/`02:631E`. The per-cell `_Random` fill is not isolated as a loop in this branch. `02:5264` (`cplx_swap_dispatch`) is **not** randM — its only caller is `62D0`, in the `0xBD` complex-operand branch. The randM cell-fill body stays open. [H] |
 | `List►matr(` | `0x8E` @ `61C1` | `02:7D19` + copy | reshapes the argument lists into a matrix (`_DataSize`-counted float copy `4539`/`453F`). [H] |
 
-The shared element-loop kernels these drivers call are the per-element apply at `02:412A` (not a
-defined function in the live DB; address unverified [H]) and `mrow_swap_loop` (`02:414E`). The
-dispatch *sites* (`6379`, `62D0`, `6397`) are byte-confirmed; the command→body *behaviour* mapping
-is not, and is flagged for re-tracing through the page-02 dispatcher. [H]
+The matrix-element kernels these drivers share are `_AdrMEle`/`_AdrMRow` (`4002`/`4000`) for indexing,
+`4068` (`mele_store_ckvalid`) for validated stores, and `4539` (`mele_copy9_d3`) for the bulk
+column-major payload copy. Each command's dispatch site **and** body are byte-confirmed above; the
+single residual is `randM(`'s per-cell fill and `4663`'s elimination role inside `augment(`. [C for
+the bodies; H for those two residuals]
 
 ---
 
@@ -452,12 +467,15 @@ and the routine and condition that triggers it.
 | `02:406C` | `_PutToMat` | OP1 → `[M](i,j)` (validated) [C] |
 | `02:40BA` | Ghidra auto-name (retired) | not a defined function in the current Ghidra DB; was an earlier-pass auto-name with no WikiTI/inc backing (`0x40BA` in ti83plus.inc is the unrelated `_SinCosRad` bcall ID). Inferred matrix-multiply body; address unverified (§4) |
 | `02:4108` | `identity_build` | `identity(n)`: diagonal-1 fill (token 0xB4) [C] |
-| `02:412A` | (undisassembled) | per-element matrix unary/binary apply; not a defined function in the current Ghidra DB, structure inferred, address unverified [H] |
+| `02:412A` | `mat_transpose` | **transpose `[A]ᵀ`** body (token `0x0E`, dispatched `60E9`/called `60FE`): per-cell copy `dst(c,r)=src(r,c)` via the swapped dest header (§4) [C] |
 | `02:414E` | `mrow_swap_loop` | row swap/scale (elimination) [C] |
-| `02:4178` | `mat_fill_type1` | live DB name; single-counter per-cell fill/apply loop — **not** transpose. Transpose body unresolved (§4) [H] |
-| `02:4663` | `mat_gauss_engine` | live DB name; `min(H,L)` non-square elimination engine called from the `augment(` `0x91` branch (`6379`) — **not** a column-concat. augment body needs re-tracing (§4) [H] |
-| `02:5264` | `cplx_swap_dispatch` | live DB name; complex OP-pair arrange/swap (`5344`/`52D3`) reached from the `0xBD` branch (`62D0`) — **not** `randM(` random-fill. randM body needs re-tracing (§4) [H] |
-| `02:49E3` | `lele_copy_until_eq` | live DB name; list-element copy-until-length-match (`21BB`, `RET Z`) called from the `Matr►list(` `0x8D` branch (`6397`) — exact command-body extent needs re-tracing (§4) [H] |
+| `02:4178` | `mat_fill_type1` | live DB name; single-counter per-cell fill/apply loop in the `414A`–`4178` block — **not** transpose (§4) [C] |
+| `02:4539` | `mele_copy9_d3` | bulk column-major float-payload copy (skip 2 dim bytes, `LDIR`); used by `augment(`/reshape (§4) [C] |
+| `02:4663` | `mat_gauss_engine` | live DB name; `min(H,L)` partial-pivoting elimination engine; only caller is the `augment(` `0x91` branch (`6379`). Its role inside plain `augment(` is the one open item (§4) [H] |
+| `02:4773` | `mat_to_list_cols` | **`Matr►list(`** 2-arg column-extract engine (only caller `63A0`): nested col×row walk copying matrix columns into list element(s) (§4) [C] |
+| `02:5264` | `cplx_swap_dispatch` | live DB name; complex OP-pair arrange/swap (`5344`/`52D3`) reached only from the `0xBD` branch (`62D0`) — **not** `randM(` random-fill (§4) [C] |
+| `02:6238` | `mat_augment_copy` | **`augment(`** column-concat: allocate result (`5DE0`) + `4539` payload copy + re-point `84D3` (§4) [C] |
+| `02:49E3` | `lele_copy_until_eq` | live DB name; list-element copy-until-length-match (`21BB`, `RET Z`); inner copy of the `Matr►list(` 1-arg/list path (`6397`) (§4) [C] |
 | `02:41C1` | `abs_cmp_op1op2` | absolute-value compare: OP1 vs pivot [C] |
 | `02:41D0` | `pivot_col_scan` | partial-pivot: find largest absolute value in column [C] |
 | `02:4259` | `perm_swap` | swap two entries of the permutation vector (84D5) [C] |
@@ -503,21 +521,25 @@ and the routine and condition that triggers it.
   the magnitude is the `238B`/`RST 30h` diagonal-pivot accumulate (`43E3–43F6`); `420F`/`4259`
   undo the column permutation for the inverse (§5). Row/col vs dim0/dim1 is now **[C]**:
   `dim0` (first header byte) = #rows, and `_AdrMEle` takes `B=column`, `C=row` (§1/§2).
-- **OPEN — per-function matrix driver bodies need re-tracing.** The page-02 dispatch *sites* are
-  byte-confirmed, but the called functions the live Ghidra DB names there do **not** match the
-  command claims, so these command→body mappings are downgraded to [H] (§4):
-  - `augment(` `0x91` branch (`6379`) calls `02:4663` = `mat_gauss_engine` — a `min(H,L)` non-
-    square **elimination** engine, not a column-concat. The concat copy is the branch's `6238`
-    step; the true augment body is unresolved.
-  - `randM(` `0xB5` branch routes to `5CEB`, not to `02:5264` = `cplx_swap_dispatch` (a complex
-    OP-pair swap reached from the `0xBD` branch at `62D0`). The randM cell-fill body is unresolved.
-  - `Matr►list(` `0x8D` branch (`6397`) calls `02:49E3` = `lele_copy_until_eq`, a list-element
-    copy-until-length-match; whether that is the whole command body or just its inner copy step is
-    unresolved.
-  - transpose `[A]ᵀ`: `02:4178` is `mat_fill_type1` (a single-counter per-cell fill/apply), not a
-    transpose; the transpose body is unresolved.
+- **RESOLVED — transpose, `Matr►list(`, and the `augment(` column-concat bodies.** Each command's
+  page-02 dispatch site **and** body are byte-confirmed, every body having exactly one caller (§4):
+  - transpose `[A]ᵀ` (token `0x0E` @ `60E9`) → **`02:412A`** (only caller `60FE`): the dim header is
+    swapped (`60F5`) and `412A` copies `dst(c,r)=src(r,c)` over every cell. `02:4178` is a separate
+    single-counter fill/apply, not transpose. [C]
+  - `Matr►list(` (`0x8D` @ `6388`) → **`02:4773`** (2-arg column-extract engine, only caller `63A0`)
+    with `02:49E3` as the 1-arg/list inner copy. [C]
+  - `augment(` (`0x91` @ `635B`) → equal-rows guard (`CP L ; JP NC,2719`) + **column-concat copy at
+    `02:6238`** (`5DE0` allocate + `02:4539` `LDIR` payload copy). [C]
+  - `randM(` (`0xB5` @ `62D4`) → creates the result and sets its dims (`5DBB`/`5DEB`). `02:5264`
+    (`cplx_swap_dispatch`, only caller `62D0` in the `0xBD` branch) is confirmed **not** randM. [C]
   - `List►matr(` `0x8E` branch (`61C1`) → `02:7D19` + `_DataSize` copy (`4539`/`453F`) is
     unchanged [H].
+- **OPEN — two residuals inside the confirmed branches** (§4):
+  - `augment(`'s `0x91` branch calls `02:4663` (`mat_gauss_engine`, only caller `6379`) — a
+    `min(H,L)` partial-pivoting elimination pass — after the column-concat copy. Its role for plain
+    `augment(` is byte-confirmed as a call but not explained. [H]
+  - `randM(`'s per-cell `_Random` fill is not isolated as a loop in the `0xB5` branch (the visible
+    calls create the matrix and convert the dims). [H]
 - `seq(`/`SortA(`/`SortD(`/stats list-builders: confirm the collect-then-`_CreateRList` loop
   and the in-place float sort/compare. (Residual — comparator `_CpOP1OP2` confirmed; the
   unanalyzed page-02 sort body's element-load is still not byte-traced.)

--- a/docs/sub-matrix-list.md
+++ b/docs/sub-matrix-list.md
@@ -228,7 +228,9 @@ sort body's element-load is not byte-traced]
   ```
 - **`Fill(value,[M])`** / **`randM(`** stamp a constant / random values across all cells via a
   per-cell loop over the whole matrix. `randM(` builds the result through the `0xB5` dispatcher
-  branch (`02:62D4`); its per-cell fill body is the one residual still open (§4). [H]
+  branch (`02:62D4` → `5CEB`, which `_FindSym`s the result var via `RST 10h` then fragments in the
+  live DB); the per-cell fill — expected to draw from `_Random` (bcall `0x4B79`, seeds at
+  `9640`/`9649`) — is the one residual still open (§4). [H]
 - Matrix **copy/reshape** = `_DataSize`-counted byte copy of the float payload
   (`mele_copy9_d3` (`02:4539`)/`mele_copy9_loop` (`02:453F`)). [C]
 

--- a/docs/sub-matrix-list.md
+++ b/docs/sub-matrix-list.md
@@ -240,8 +240,7 @@ sibling in the same `412A`–`414E` family and is inferred here. [H]
 
 ### `[A] * [B]` — matrix multiply [H]
 The matrix-multiply body is not a defined function in the current Ghidra DB; the O(n³) structure
-below is inferred, address unverified. The `02:40BA` label was a Ghidra auto-name from an earlier
-analysis pass with no WikiTI or ti83plus.inc backing. (`0x40BA` does appear in ti83plus.inc, but
+below is inferred, address unverified. The `02:40BA` label is a Ghidra auto-name with no WikiTI or ti83plus.inc backing. (`0x40BA` does appear in ti83plus.inc, but
 as the unrelated `_SinCosRad` bcall ID — a hex coincidence, not matrix-mult provenance.) The `*`
 dispatch site `02:5FE6` and the result-setup site `02:5766` are likewise undisassembled in the
 live DB.
@@ -299,7 +298,7 @@ body and its single caller are byte-verified below.
 |---|---|---|---|
 | `Matr►list(` | `0x8D` @ `6388` | **`02:4773`** (2-arg), `02:49E3` (1-arg list copy) | [C] The `0x8D` branch splits on argument count (`638D: CP 0x02`). The **column-extract engine is `02:4773`** (2-arg path: `639D: CALL 5DD8 ; CALL 4773`; only caller `63A0`, byte-verified `CD 73 47`): it nests a per-row loop (`477B: LD B,1 …`, reading via `4040` `_AdrMRow`/`4068` `mele_store_ckvalid`) inside a column loop over `(84AF)`, copying matrix columns into list element(s) (`4051`/`479F`). The 1-arg/list path uses `02:49E3` (`6397: CALL 0x49E3`), a list-element copy-until-length-match (`47E6` recall, `4825` store, `21BB` compare vs `(84AF)`, `RET Z`). |
 | transpose `ᵀ` | `0x0E` @ `60E9` | **`02:412A`** | [C] Swaps the dim header (`60F5`), allocates the transposed shape, then `412A` copies `dst(c,r)=src(r,c)` over every cell (`403C` read from `(84D3)`, `4068` write to `(84D7)`); only caller `60FE`. See the transpose subsection above. |
-| `augment(` | `0x91` @ `635B` | **`02:6238` copy** [C]; `02:4663` engine [H] | The `0x91` branch requires two operands (`CP 0x02`), reads the dims (`5D98`), and applies an equal-rows guard `LD A,H ; CP L ; JR Z ; JP NC,2719` (`E_Dimension` when the row counts differ). It then runs the **column-concatenation copy at `02:6238`** [C]: `6238` allocates the result (`5DE0` → `5DE6` → `_CreateRMat 110F`) and bulk-copies the float payload with `02:4539` (`mele_copy9_d3` — skip the 2 dim bytes, `LDIR` the column-major data), re-pointing `84D3←84D7`. The branch then calls `02:4663` (`6379`, only caller; byte-verified `CD 63 46`), a partial-pivoting elimination engine: it computes `min(H,L)` (`4672: LD A,H ; CP L ; JR C ; LD L,H`), inits via `475E`, and iterates from `BC=0x0101` calling `461C` (max-abs), `41D0` (pivot-column scan), `198D` (compare), `471C` (permutation swap) and `405E` (store). The column-concat copy (`6238`/`4539`) is confirmed augment behaviour [C]; `4663`'s elimination pass on the concatenated result is byte-confirmed but its role for plain `augment(` is left open [H]. (`augment(L1,L2)` list-concat is the `0x92` sibling at `637F`, sharing the `6362` setup.) |
+| `augment(` | `0x91` @ `635B` | **`02:6238` copy** [C]; `02:4663` engine [H] | The `0x91` branch requires two operands (`CP 0x02`), reads the dims (`5D98`), and checks the two row counts with `LD A,H ; CP L`: equal rows fall through (`JR Z`) and `H>L` raises `E_Dimension` (`JP NC,2719`). It then runs the **column-concatenation copy at `02:6238`** [C]: `6238` allocates the result (`5DE0` → `5DE6` → `_CreateRMat 110F`) and bulk-copies the float payload with `02:4539` (`mele_copy9_d3` — skip the 2 dim bytes, `LDIR` the column-major data), re-pointing `84D3←84D7`. The branch then calls `02:4663` (`6379`, only caller; byte-verified `CD 63 46`), a partial-pivoting elimination engine: it computes `min(H,L)` (`4672: LD A,H ; CP L ; JR C ; LD L,H`), inits via `475E`, and iterates from `BC=0x0101` calling `461C` (max-abs), `41D0` (pivot-column scan), `198D` (compare), `471C` (permutation swap) and `405E` (store). The column-concat copy (`6238`/`4539`) is confirmed augment behaviour [C]; `4663`'s elimination pass on the concatenated result is byte-confirmed but its role for plain `augment(` is left open [H]. (`augment(L1,L2)` list-concat is the `0x92` sibling at `637F`, sharing the `6362` setup.) |
 | `randM(` | `0xB5` @ `62D4` | create + dim setup (`5DBB`/`5DEB`); cell-fill body open [H] | The `0xB5` branch splits on argument count (`62D9: CP 0x02`): the 2-arg `randM(rows,cols)` path (`62DD`) and the 1-arg square path (`630A`). Both **create the result and set its dims** through `02:5DBB` (`CALL 5CEB` registers the variable by name, stores the data pointer to `84D3`, reads and zero-rejects the dim bytes `OR L ; JP Z,2719`, stores dims to `84AF`) and `02:5DEB`/`02:631E`. The per-cell `_Random` fill is not isolated as a loop in this branch. `02:5264` (`cplx_swap_dispatch`) is **not** randM — its only caller is `62D0`, in the `0xBD` complex-operand branch. The randM cell-fill body stays open. [H] |
 | `List►matr(` | `0x8E` @ `61C1` | `02:7D19` + copy | reshapes the argument lists into a matrix (`_DataSize`-counted float copy `4539`/`453F`). [H] |
 
@@ -313,9 +312,10 @@ the bodies; H for those two residuals]
 
 ## 5. The heavy ones — `det(`, `[A]⁻¹`, `rref(` / `ref(` [C]
 
-All three are the **same Gauss-Jordan elimination engine with partial pivoting**:
-**`matrix_gauss_engine` @ `page_02:42A6`**. The *entry flag in `A`* selects behaviour. Only two
-direct call sites exist (byte-verified — `CD A6 42` appears exactly twice):
+`det(` and `[A]⁻¹` share the **Gauss-Jordan elimination engine with partial pivoting** —
+**`matrix_gauss_engine` @ `page_02:42A6`** — the *entry flag in `A`* selecting behaviour; only two
+direct call sites exist (byte-verified — `CD A6 42` appears exactly twice). `rref(`/`ref(` are a
+**separate** driver and do not call `42A6` (see below):
 
 | Token / op | site | flag `A` | meaning |
 |---|---|---|---|
@@ -397,7 +397,7 @@ So the **sign byte is the LSB of the swap-count** applied via `_InvOP1S` (`00:24
 **`rref(`/`ref(` do not re-enter the `42A6` Gauss-Jordan engine.** A function-xref shows
 `matrix_gauss_engine` (`02:42A6`) has **exactly two callers** — `mat_inverse_entry` (`02:5F80`,
 flag 0) and `det_entry` (`02:5FC0`, flag 0x40); there is no third call site (byte-confirmed
-earlier: `CD A6 42` appears exactly twice). So `det(`/`[A]⁻¹` are the only consumers of that
+above: `CD A6 42` appears exactly twice). So `det(`/`[A]⁻¹` are the only consumers of that
 square-only, partial-pivoting driver. [C]
 
 `rref(` (`BBh,A6h`) and `ref(` (`BBh,A5h`) are **2-byte `0xBB`-lead function tokens**. On the
@@ -465,7 +465,7 @@ and the routine and condition that triggers it.
 | `02:4002` | `_AdrMEle` | matrix element address: `((column-1)*dim0+(row-1))*9` [C] |
 | `02:4044` | `_GetMToOP1` | `[M](i,j)` → OP1 [C] |
 | `02:406C` | `_PutToMat` | OP1 → `[M](i,j)` (validated) [C] |
-| `02:40BA` | Ghidra auto-name (retired) | not a defined function in the current Ghidra DB; was an earlier-pass auto-name with no WikiTI/inc backing (`0x40BA` in ti83plus.inc is the unrelated `_SinCosRad` bcall ID). Inferred matrix-multiply body; address unverified (§4) |
+| `02:40BA` | Ghidra auto-name (retired) | not a defined function in the current Ghidra DB and has no WikiTI/inc backing (`0x40BA` in ti83plus.inc is the unrelated `_SinCosRad` bcall ID). Inferred matrix-multiply body; address unverified (§4) |
 | `02:4108` | `identity_build` | `identity(n)`: diagonal-1 fill (token 0xB4) [C] |
 | `02:412A` | `mat_transpose` | **transpose `[A]ᵀ`** body (token `0x0E`, dispatched `60E9`/called `60FE`): per-cell copy `dst(c,r)=src(r,c)` via the swapped dest header (§4) [C] |
 | `02:414E` | `mrow_swap_loop` | row swap/scale (elimination) [C] |

--- a/docs/sub-statistics.md
+++ b/docs/sub-statistics.md
@@ -18,8 +18,7 @@ fixed page‑0 core at `0x0000`. The whole STAT‑CALC engine lives on **flash p
 0x3A**. Confidence: **[confirmed]** = read from Z80 disassembly, **[standard]** =
 matches documented TI behavior, **[hypothesis]** = inferred.
 
-Verified by headless disassembly/decompilation on the private Ghidra copy
-(`/tmp/ti84-stats`). Note the Ghidra decompiler mis-renders the Z80
+The Ghidra decompiler mis-renders the Z80
 `SET/RES b,(IY+d)` flag ops, the `RST` macros, and cross-page `CALL 0x2b09`
 trampolines, so the algorithm here is read primarily from the **disassembly**.
 

--- a/docs/sub-vat-archive.md
+++ b/docs/sub-vat-archive.md
@@ -6,8 +6,8 @@ Deep-dive companion to [05-variables-vat.md](05-variables-vat.md) and [12-memory
 program that manages memory touches: the VAT walk (`_FindSym`), variable Store/Recall, and the
 **Archive / UnArchive** path (RAM ↔ Flash), the Flash **garbage collector**, and the memory checks.
 
-Every address here is verified by **disassembling the actual Z80** in the Ghidra DB (`/tmp/ti84-vat`,
-headless `Disasm.java`) rather than by the decompiler alone, which mis-renders the `SET b,(IY+d)` flag ops and
+Every address here is read from the raw Z80 disassembly rather than the decompiler alone, which
+mis-renders the `SET b,(IY+d)` flag ops and
 the cross-page `CALL 0x2b09`-style trampolines. Page numbers are the masked flash page
 (`rawpage & 0x3F`); cross-page trampolines store `lo hi rawpage` in the 3 bytes after the `CALL`.
 
@@ -373,5 +373,4 @@ Ports: **0x06** = bank-A page select (Flash window), **0x14** = Flash write/eras
   separate routine that walks the group's member list. That member-walk routine is **not
   identifiable in the current Ghidra DB** — `_Arc_Unarc`'s body past the entry `CALL` is not
   disassembled here (cross-page `CALL` flagged non-returning), and no group-archive function is
-  named or xref-reachable. Re-confirming it would need the headless `Disasm.java` linear pass that
-  produced §4.
+  named or xref-reachable. Re-confirming it would need a linear disassembly pass like the one behind §4.


### PR DESCRIPTION
Continuation of the conformance/grounding work after PR #2 merged. Branched off the updated `main`.

## Matrix command bodies re-verified vs the live Ghidra DB
- **Same-function relabels** to live names (`[C]` kept): `mat_row_op`→`mrow_swap_loop`, `pivot_abs_cmp`→`abs_cmp_op1op2`, `row_dot_accum`→`col_dot_accum`, `elim_sub_step`→`ele_sub_ref`, `classify_elem_width`→`chk_type_lt_1a`.
- **Genuine mis-traces** (doc mapped commands to the wrong bodies) downgraded `[C]`→`[H]` with disassembly evidence: `02:4178` is `mat_fill_type1` (not transpose); `02:4663` is an elimination engine computing `min(rows,cols)` (not augment — augment's column-copy is at `6238`; `4663` is the likely `rref`/`ref` engine §5 couldn't isolate); `02:5264` is `cplx_swap_dispatch` (not randM — fill is behind `5CEB`); `02:49E3` is `lele_copy_until_eq`. Real bodies flagged OPEN for re-tracing through the `02:60C8` dispatcher.

## 2nd / ALPHA modifier state machine (new, RE'd from `_GetKey`)
Added to `09-keyboard-link.md`: `shiftFlags` (`IY+0x12`=`0x8A02`) bit table + a **Mermaid state diagram**, every transition byte-traced — `[2nd]` SET b3 @4AD5 (one-shot, RES @4B87); `[ALPHA]` SET b4 @4AE8; **2nd+ALPHA → alpha lock** SET b6+b4 @4B96; `[ALPHA]`-in-alpha upper→lower @4C0D; `[2nd]`-in-alpha @4C25.

## Deslop
Dropped stale local-tooling refs (`/tmp/ti84-*`, headless `Disasm.java`/`Dec.java`) from the deep-dive intros; kept the substantive decompiler caveat (`conventions.md` states it canonically).

Build clean; address guards clean.