### PR TITLE
Render MathPrint formats as C structs

### DIFF
--- a/docs/05-variables-vat.md
+++ b/docs/05-variables-vat.md
@@ -50,10 +50,10 @@ typedef struct {
 typedef struct { TIFloat re, im; } TIComplex;                   /* 18 bytes */
 
 /* ── aggregate data (what the VAT entry's dataAddr points at) ──────── */
-struct List   { uint16_t count;       TIFloat elem[/*count*/];     }; /* ListObj 1; CListObj 0x0D uses TIComplex[] */
-struct Matrix { uint8_t  rows, cols;  TIFloat elem[/*rows*cols*/];  }; /* MatObj 2, stored column-major (rows = dim0) */
-struct Tokens { uint16_t size;        uint8_t body[/*size*/];      }; /* EquObj 3, StrngObj 4, ProgObj 5/6 — tokenized */
-struct AppVar { uint16_t size;        uint8_t data[/*size*/];      }; /* AppVarObj 0x15 — RAW bytes, not tokenized     */
+struct List   { uint16_t count;       TIFloat elem[/* count */];         }; /* ListObj 1; CListObj 0x0D uses TIComplex[] */
+struct Matrix { uint8_t  rows, cols;  TIFloat elem[/* rows * cols */];  }; /* MatObj 2, stored column-major (rows = dim0) */
+struct Tokens { uint16_t size;        uint8_t body[/* size */];          }; /* EquObj 3, StrngObj 4, ProgObj 5/6 — tokenized */
+struct AppVar { uint16_t size;        uint8_t data[/* size */];          }; /* AppVarObj 0x15 — RAW bytes, not tokenized     */
 ```
 
 Per object type:
@@ -87,7 +87,7 @@ struct VATEntry {
     uint16_t dataAddr;      /* RAM address of the data — or an offset into Flash if archived */
     uint8_t  dataPage;      /* Flash page holding the data (0 = data is in RAM)              */
     uint8_t  nameLen;       /* length of the name that follows                               */
-    uint8_t  name[/*nameLen*/];
+    uint8_t  name[/* nameLen */];
 };
 ```
 

--- a/docs/sub-equation-display.md
+++ b/docs/sub-equation-display.md
@@ -69,13 +69,18 @@ A visible expression is driven by **handler records** reached through the class 
 handler = word(39:5E45 + 2 * class)
 ```
 
-Most entries point to compact data, not executable code. The common record format is:
+Most entries point to compact data, not executable code. The common record format is a
+variable-length tail:
 
-```text
-byte row_count
-byte cell_count[row_count]
-byte row_action[row_count]
-word cell[sum(cell_count)]
+```c
+typedef uint16_t EqDispCell;  /* high byte D, low byte E */
+
+typedef struct {
+    uint8_t row_count;
+    uint8_t cell_count[];  /* row_count entries */
+    /* uint8_t row_action[row_count]; */
+    /* EqDispCell cell[sum(cell_count[0..row_count - 1])]; */
+} EqDispHandlerRecord;
 ```
 
 `row_action[]` bytes are row labels or control actions. They are separate from the cell
@@ -164,12 +169,14 @@ the final MathPrint operator form. [confirmed]
 
 Descriptor-backed templates use a fixed ABI. A descriptor is:
 
-```text
-word base_yx
-word box_yx
-byte row_height
-word cols_rows
-word cell_pointer
+```c
+typedef struct {
+    uint16_t base_yx;       /* packed base y/x coordinate */
+    uint16_t box_yx;        /* packed box y/x coordinate */
+    uint8_t  row_height;
+    uint16_t cols_rows;     /* packed column/row count */
+    uint16_t cell_pointer;  /* pointer to descriptor cells */
+} EqDispTemplateDescriptor;
 ```
 
 The mapper at `39:683D` converts a descriptor cell to pixels:

--- a/docs/sub-table-yvars.md
+++ b/docs/sub-table-yvars.md
@@ -188,7 +188,7 @@ its handler vectors run on page 05.
 ### Editor main display — `table_editor_main` (`05:5D0D`) [confirmed]
 
 ```c
-if (tblFlags & 0x40 /*reTable*/) recompute = table_recompute()  ; 05:5DD7
+if (tblFlags & 0x40 /* reTable */) recompute = table_recompute()  ; 05:5DD7
 else                              use_cache  = table_use_cache() ; 05:78CF
 if (graphFlags & 1) { redraw helpers ... }                       ; split-graph case
 paint_grid(...)                                                  ; 05:7771
@@ -229,7 +229,7 @@ i.e. the first row's independent value is **TblStart**. A working float at
 ```z80
 05:65DC  … LD HL,(table indices) … CALL 0x6D67 (advance) …
 05:6359  LD A,(0x91DD) … LD DE,0x9221 / 0x91E2 (cell buffers)
-         LD HL,(0x91DC /*row idx*/) ; ADD ; CALL _LdHLind ; ADD HL,DE
+         LD HL,(0x91DC /* row idx */) ; ADD ; CALL _LdHLind ; ADD HL,DE
 ```
 
 So row $k$ uses $X=\mathrm{TblMin}+k\cdot\mathrm{TblStep}$. (In **Indpnt = Ask** mode this driver is


### PR DESCRIPTION
## Summary
- render the MathPrint handler-record and template-descriptor layouts as C structs
- normalize compact C comments in existing struct examples, e.g. `/* rows * cols */`
- fix inline compact comments in the TABLE/Y= page

## Validation
- `rg -n '/\\*[^ ]|[^ ]\\*/' docs/*.md README.md || true`
- `git diff --check`
- `nix build`
