### PR TITLE
Document USB ASIC link-assist path

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ A Z80 (64 KiB address space) with hardware **paging** maps flash page 0 at `0000
 | [13](docs/13-flash-page-map.md) | What each of the 64 flash pages holds |
 | [99](docs/99-open-questions.md) | Future-work roadmap |
 
-**Subsystem deep-dives** (from parallel multi-agent RE): `sub-calculation`, `sub-graphing`, `sub-tibasic`, `sub-vat-archive`, `sub-apps-mem-settings`, `sub-statistics`, `sub-matrix-list`, `sub-solver-numeric`, `sub-table-yvars`, `sub-equation-display`, `sub-link-transfer`.
+**Subsystem deep-dives** (from parallel multi-agent RE): `sub-calculation`, `sub-graphing`, `sub-tibasic`, `sub-vat-archive`, `sub-apps-mem-settings`, `sub-statistics`, `sub-matrix-list`, `sub-solver-numeric`, `sub-table-yvars`, `sub-equation-display`, `sub-link-transfer`, `sub-usb-asic`.
 
 **Reference**: [`glossary`](docs/glossary.md) (terms & key RAM symbols), [`conventions`](docs/conventions.md) (notation, confidence flags, methodology), [`bcall-index`](docs/bcall-index.md) (main bcalls plus unverified extended entries, alphabetical), [`token-tables`](docs/token-tables.md) (492 two-byte tokens, from TI-Toolkit/tokens).
 

--- a/docs/00-system-overview.md
+++ b/docs/00-system-overview.md
@@ -48,8 +48,9 @@ Each row maps a documentation page to the subsystem it covers and its analysis s
 | [sub-table-yvars.md](sub-table-yvars.md) | TABLE generation/cache, Y= equation vars | ✅ |
 | [sub-equation-display.md](sub-equation-display.md) | Equation display / MathPrint layout (page 0x39 `eqdisp_*`) | ✅ |
 | [sub-link-transfer.md](sub-link-transfer.md) | Link protocol: byte/packet/var-transfer (page 0x3C) | ✅ |
+| [sub-usb-asic.md](sub-usb-asic.md) | USB ASIC/link-assist ports and OS transport selection | ✅ |
 
-(The `sub-*` docs are deep dives covering user-facing functionality: calculation, graphing, TI-BASIC, VAT/archive, apps, stats, matrices, solver, table, and link.)
+(The `sub-*` docs are deep dives covering user-facing functionality and I/O internals: calculation, graphing, TI-BASIC, VAT/archive, apps, stats, matrices, solver, table, equation display, link, and USB/link assist.)
 
 New to these notes? Start with [Conventions & Methodology](conventions.md) (how to read the addresses and confidence flags) and the [Glossary](glossary.md); the [bcall Index](bcall-index.md) is the full alphabetical system-call reference.
 

--- a/docs/01-memory-map.md
+++ b/docs/01-memory-map.md
@@ -55,6 +55,8 @@ Pages `01–3F` are loaded in Ghidra as overlays `page_01 … page_3F` (each at 
 | `05` | mapBankC | RAM page in slot `C000` (MemC) on the 84+ |
 | `06` | mapBankA | Flash page in slot `4000` |
 | `07` | mapBankB | Page in slot `8000` (`0x81`=84+ mode seen in ISR) |
+| `08`-`0D` | usb/link assist | 84+ hardware byte-assist control/status/data/FIFO ports; see [USB ASIC and link assist](sub-usb-asic.md) |
 | `10/11` | lcdCmd/lcdData | LCD controller |
 | `20` | cpuSpeed | 0=6 MHz, 1=15 MHz (set in ISR) |
+| `4D` | usbLineState | USB line-state gate sampled by `_LinkXferOP`; bits 5/6 gate the unresolved `ram:2E48` call path |
 | `55/56` | usbIntStatus/usbLineEvents | USB interrupt state / line events (84+) — polled first in `int_dispatch_sources`; both read-only (port 0x56 is a read-only event bitmap, not a write mask) |

--- a/docs/09-keyboard-link.md
+++ b/docs/09-keyboard-link.md
@@ -98,7 +98,7 @@ So the input path is: keypad → ISR → `kbdScanCode` → `_GetKey` (cooked `kX
 
 ## Link port
 
-The 2.5 mm I/O link has two open-collector lines (tip/ring), driven via **port 0** (`port_link`), with an 84+ **hardware link-assist / USB** path via ports `0x08/0x09/0x0D`.
+The 2.5 mm I/O link has two open-collector lines (tip/ring), driven via **port 0** (`port_link`), with an 84+ **hardware link-assist / USB** path via ports `0x08`-`0x0D`. See [USB ASIC and link assist](sub-usb-asic.md) for the ASIC-facing port map and the `_LinkXferOP` USB-selection gate.
 
 `_SendAByte` (`3C:420D`) shows both paths **[confirmed]**:
 - **Hardware-assisted** (when enabled): poll status `port 0x09` bit 5 (ready), then write the byte to `port 0x0D`; helper routines on page 3C manage the assist FIFO/timing.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -42,6 +42,7 @@
 - [Table & Y= variables](sub-table-yvars.md)
 - [Equation display (MathPrint)](sub-equation-display.md)
 - [Link / data transfer](sub-link-transfer.md)
+- [USB ASIC and link assist](sub-usb-asic.md)
 
 # Reference
 

--- a/docs/sub-link-transfer.md
+++ b/docs/sub-link-transfer.md
@@ -5,7 +5,8 @@
 Deep-dive companion to [09-keyboard-link.md](09-keyboard-link.md), focused on what a **student transferring data**
 touches: pushing a program/list/etc. to a computer (TI-Connect) or another calculator over the
 2.5 mm I/O link or the 84+ USB/hardware link-assist. Builds the full stack on top of [doc 09](09-keyboard-link.md)'s byte
-primitives `_SendAByte` (`3C:420D`) and `_RecAByteIO` (`3C:443F`).
+primitives `_SendAByte` (`3C:420D`) and `_RecAByteIO` (`3C:443F`); the ASIC-facing assist/USB ports
+are covered separately in [USB ASIC and link assist](sub-usb-asic.md).
 
 Addresses here are read from the raw Z80 disassembly. The decompiler mis-renders this subsystem —
 it passes arguments in registers and does its state work with `SET/RES/BIT b,(IY+d)` flag ops that the
@@ -378,11 +379,12 @@ silent-link engine documented here. **[C for 0x9F path; H for the 0x22-25 mappin
 | `00:50DD` | `_GetSysInfo` | system info reply (used in link sessions) |
 | `00:4A14` | `_SendVarCmd` (bcall id) | → 3C:4EDD |
 
-**Ports:** `0x00` = bit-bang link (tip/ring); `0x08/0x09/0x0D` = HW link-assist (status/control/data
-FIFO — port 0x09 bit5 TX-ready, bit6 transmission-error, bit4 byte-received, bits 0x19 error);
+**Ports:** `0x00` = bit-bang link (tip/ring); `0x08`-`0x0D` = HW link-assist control/status/data
+FIFO (port 0x09 bit5 TX-ready, bit6 transmission-error, bit4 byte-received, bits 0x19 error);
 `0x02` bit7 = non-83+-Basic (assist-present gate on 84+; WikiTI's "link-assist available" is bit6);
 `0x20` = CPU speed (timeout scaling); `0x4D` bits5/6 = USB negotiation; `0x14` = Flash
-write/erase (received-to-archive path). RAM block: `ioFlag 8670 … bakHeader 868B`, staging
+write/erase (received-to-archive path). See [sub-usb-asic.md](sub-usb-asic.md) for the assist port
+state machine. RAM block: `ioFlag 8670 … bakHeader 868B`, staging
 `pagedBuf 983A`.
 
 **Command IDs:** 0x06 VAR · 0x09 CTS · 0x15 DATA · 0x2D DEL · 0x36 SKIP/EXIT · 0x56 ACK ·
@@ -394,5 +396,5 @@ write/erase (received-to-archive path). RAM block: `ioFlag 8670 … bakHeader 86
   them vs. the blanket 0x9F here. [H]
 - Backup (sndRecState 0x08 / varClass 0x0A) framing detail in `40DA` (the 0x37D clamp + 0x63 00
   prefix) — full backup-packet layout. [H]
-- The USB stack proper (port 0x4D, the `cross_page 2E0B` host negotiation) lives off page 3C and is
-  not traced here.
+- The target at `ram:2E48`, called after `_LinkXferOP` samples port `0x4D`, is not a function in
+  the current Ghidra database. Its exact side effects remain open; see [sub-usb-asic.md](sub-usb-asic.md).

--- a/docs/sub-usb-asic.md
+++ b/docs/sub-usb-asic.md
@@ -1,0 +1,197 @@
+# USB ASIC and link assist
+
+*TI-84 Plus OS 2.55MP - feature deep dive.*
+
+This page covers the OS-visible USB/link-assist hardware interface: the Z80 I/O ports the ROM uses,
+the byte FIFO path used by the link layer, and the places where `_LinkXferOP` chooses USB before
+falling back to the 2.5 mm link. It complements [Link / data transfer](sub-link-transfer.md), which
+covers the TI link packet protocol and variable-transfer state machine.
+
+The full USB controller is broader than the variable-transfer path. This page is ROM-grounded: the
+confirmed claims below come from OS 2.55MP disassembly/decompilation and cite the address ranges that
+show them. External WikiTI names are used only as orientation where noted, not as proof.
+
+## ROM-grounded surface
+
+The ROM shows three transport-facing surfaces:
+
+| Layer | Port range | Role |
+|-------|------------|------|
+| Legacy link | `0x00` | 2.5 mm tip/ring open-collector byte path. [confirmed: `3C:6C99`, `3C:6CF3`] |
+| Link-assist FIFO | `0x08`-`0x0D` | Hardware byte send/receive assist used below `_SendAByte` and `_RecAByteIO`. [confirmed: `3C:6BB1`-`6D53`] |
+| USB line / interrupt gates | `0x4D`, `0x55`, `0x56` | Line-state and event/status gates used before and during link handling. [confirmed: `3C:4E4A`, `00:006F`] |
+
+In the variable-transfer code, the OS mostly treats USB as a transport selector around the existing
+TI link protocol. The packet layer still sends machine IDs, command bytes, checksums, ACK/NAK, and
+EOT exactly as described in [sub-link-transfer.md](sub-link-transfer.md). The hardware difference is
+below that packet layer: bytes go through the assist FIFO when the ASIC path is enabled, and through
+port `0x00` bit-banging otherwise. [confirmed]
+
+## Observed port map [confirmed unless marked]
+
+| Port | Observed use in OS 2.55MP | Evidence |
+|------|---------------------------|----------|
+| `0x02` | Hardware/model gate before using assist paths. The link code tests bit 7 before touching ports `0x08`-`0x0D`. | `3C:6C82`, `3C:6CB8`, `3C:6D15` |
+| `0x08` | Link-assist control/idle latch. The OS writes `0x80` when clearing an inactive/error-free assist state, and `0x00` when marking the assist state active. | `3C:6C41`-`6C48`, `3C:6D38`-`6D40`, `3C:6D4B`-`6D53` |
+| `0x09` | Link-assist status. Bit 5 is TX-ready; bit 6 is a transmission/error condition; bit 4 marks a received byte. Masks `0x19`, `0x58`, and `0x99` are used as error/activity predicates. | `3C:6BB6`-`6BC5`, `3C:444A`, `3C:6BFA`, `3C:6CCE`, `3C:6D33` |
+| `0x0A` | Assist receive/data register on the confirmed receive path; also initialized with `0xB4` beside `0x0B/0x0C`. The write-side meaning of `0xB4` is still [hypothesis]. | `3C:6C20`, `3C:6C2B`, `3C:6C39` |
+| `0x0B`, `0x0C` | Assist-side configuration registers initialized with `0xB4`; semantics not decoded. [hypothesis] | `3C:6C3D`, `3C:6C3F` |
+| `0x0D` | Assist TX FIFO/data register. `_SendAByte` writes the outgoing byte here after port `0x09` bit 5 becomes set. | `3C:6BBC`-`6BBF` |
+| `0x20` | CPU speed bit used to select assist/link wait-loop reloads. The send timeout uses `0xFFFF` when bit 0 is set and `0x6800` when clear. | `3C:6BCC`, `3C:6C8B`, `3C:6CC1` |
+| `0x4D` | USB line-state gate. `_LinkXferOP` samples bits 5 and 6 before the unresolved `ram:2E48` call target. The ROM use proves only the bit tests, not the electrical names of those bits. | `3C:4E4A`-`4E6F` |
+| `0x55` | USB interrupt status, active-low in the low five bits. The IM1 dispatcher tests `(in(0x55) ^ 0xFF) & 0x1F` first. | `00:006F`-`0075` |
+| `0x56` | USB line-event bitmap used by the IM1 dispatcher after port `0x55` reports USB activity. The visible dispatcher branches on bits 1, 4, 5, 6, and 7. Event names are not derived from the ROM alone. | `00:0085`-`00AE` |
+
+The project-local `tools/ports.txt` now names the confirmed assist and USB interrupt ports so future
+Ghidra rebuilds show the same surface in the database. These labels describe the observed OS use,
+not a complete vendor register map.
+
+## Sending one byte through the assist FIFO [confirmed]
+
+The hardware send entry is `lnk_send_byte_hw` at `3C:6BB1`/`3C:6BB2` (Ghidra's function split starts
+at `6BB2`, but the byte sequence's `LD A,0xFA` begins at `6BB1`). It is the assist branch behind
+`_SendAByte` (`3C:420D`).
+
+Mechanically, it does four things:
+
+1. Seed the inner retry counter at RAM `0x9C86` with `0xFA`.
+2. Read port `0x09`.
+3. If bit 5 is set, copy the outgoing byte from `C` to port `0x0D` and return.
+4. If bit 5 is clear, call the timeout decrementer (`3C:6BDA`/`lnk_timeout_dec`) and retry until
+   the outer counter at `0x9CAC` expires, then fall into the link error path at `3C:4434`.
+
+In Z80-shaped pseudocode:
+
+```z80
+; 3C:6BB1, assist send path
+(9C86) = 0xFA
+while ((in(0x09) & 0x20) == 0) {
+    if timeout_expired(9CAC):
+        goto link_timeout
+}
+out(0x0D), C
+ret
+```
+
+`lnk_set_timeout` (`3C:6BC8`) seeds `0x9CAC` from CPU speed. When port `0x20` bit 0 is clear it uses
+`0x6800`; when the bit is set it leaves the larger `0xFFFF` seed. The ROM confirms the two reload
+values, while the wall-clock timeout they target is not measured here. [confirmed]
+
+## Receiving and status handling [confirmed]
+
+The receive path is split between `_RecAByteIO` (`3C:443F`), `lnk_rec_status` (`3C:444A`), and the
+assist helpers around `3C:6BF4`-`6D40`.
+
+The hardware-facing receive loop waits until port `0x09 & 0x58` becomes nonzero. In the confirmed
+path:
+
+- `0x40` (bit 6) is treated as a transmission/error condition.
+- `0x10` (bit 4) is the "byte received" condition.
+- `0x08` participates in the wait condition but is not fully named in this pass.
+- When the receive condition is accepted, the byte is read from port `0x0A` into `C`.
+- The status masks `0x19` and `0x99` select error/activity cases before the code resets or re-arms
+  the assist latch through port `0x08`.
+
+`lnk_rec_status` also uses the sentinel byte `0xE0`: callers pass it for a nonblocking/probe style
+receive check. If the caller requires a byte and the status path reports anything else, the code
+raises `E_LnkErr` through `_JError(0x9F)`. [confirmed]
+
+The assist reset/enable sequence at `3C:6C31` writes:
+
+```z80
+out (0x00),0x00
+out (0x09),0x97
+out (0x0A),0xB4
+out (0x0B),0xB4
+out (0x0C),0xB4
+out (0x08),0x80
+out (0x08),0x00
+in  a,(0x09)
+set 0,(IY+0x3E)
+```
+
+The sequence proves the ports touched and the RAM flag used by the OS. It does not by itself name
+the bit fields inside `0x97` or `0xB4`. [confirmed ports; bit meanings open]
+
+## USB selection in `_LinkXferOP` [confirmed]
+
+`_LinkXferOP` (`3C:4DD2`, bcall ID `0x50FB`) is the OS entry that sends a silent link request and
+prefers the USB path when its mode flags ask for it. The ROM-confirmed setup is:
+
+- `OP1` holds the variable type/name.
+- `sndRecState` (`0x8672`) is `0x15` for DATA-style receive.
+- `IY+0x1B` bit 0 selects USB-first behavior; reset means use the link port path.
+
+The OS confirms that contract in the `4E35`-`4E73` gate:
+
+1. If `IY+0x1B` bit 0 is clear, it skips USB probing and sends through the ordinary link path.
+2. If bit 0 is set and either `IY+0x1B` bit 5 or bit 6 asks for USB handling, it reads port `0x4D`.
+3. If port `0x4D` bit 5 is clear, or bit 5 is set and bit 6 is clear, the OS sets `IY+0x1B` bit 5
+   and calls the target at `ram:2E48`.
+4. Otherwise it clears `IY+0x1B` bit 5 and continues into `lnk_send_data_867d` (`3C:4055`), which
+   sends the same TI link request/VAR/DATA packets described in the link-transfer page.
+
+This makes `_LinkXferOP` a USB-first wrapper around the existing link transfer engine. It does not
+replace the packet format. The transport choice happens before `_SendAByte` writes each byte through
+the assist FIFO or falls back to port `0x00`. [confirmed]
+
+## Interrupt integration [confirmed]
+
+The IM1 dispatcher (`ram:006F`) treats the USB interrupt status as its first source gate:
+
+```z80
+in a,(0x55)
+xor 0xFF
+and 0x1F
+```
+
+If no low-five-bit USB source is active, the handler falls through to the other interrupt work. If a
+USB source is active, it reads port `0x56` and branches on event bits. In the visible dispatcher,
+bits 4, 5, 6, 7, and 1 are routed to subhandlers; the surrounding code also checks 84+ hardware mode
+through `(IY+0x09)` bit 3 and `port 0x07 == 0x81` before using the USB/timer event path. [confirmed]
+
+The timer/idle side of the same handler also bridges to the assist path. At `ram:01B1` it calls
+`ram:1850`, the same hardware-gate routine used elsewhere before assist-port access. On the legacy path it checks `port 0x00 & 0x03`; on the assist
+path it checks `port 0x09 & 0x18`. If either assist bit is set, it reloads `0x9C86 = 0xFA`, pulses
+port `0x08` with `0x80` then `0x00`, sets `IY+0x3E` bit 0, and calls the common link activity hook
+at `ram:3FD6`. [confirmed: `00:01B1`-`01DB`]
+
+For application code, this means a custom interrupt handler that does not chain to the OS handler
+must account for port `0x55`/`0x56` activity itself. The exact masking sequence is outside this
+ROM-grounded pass. [confirmed for the need to service sources; masking details open]
+
+## How to use it in code [grounded by OS calls]
+
+Prefer the OS entry points unless the program is deliberately writing a USB driver:
+
+| Need | OS surface | ROM support |
+|------|------------|-------------|
+| Send or request a variable over USB/link | `_LinkXferOP` (`50FB` -> `3C:4DD2`) or `_SendVarCmd` (`4A14` -> `3C:4EDD`) | Packet engine and USB-selection gate confirmed on page `3C`. |
+| Send one byte on the active link transport | `_SendAByte` (`4EE5` -> `3C:420D`) | Assist branch writes `C` to port `0x0D` after port `0x09` bit 5. |
+| Receive one byte on the active link transport | `_RecAByteIO` (`4F03` -> `3C:443F`) | Status path checks port `0x09` and reads port `0x0A` on the assist path. |
+| Use the raw assist FIFO | Poll port `0x09` bit 5, then write the byte to port `0x0D`; for receive, observe port `0x09` bit 4/error bits and read port `0x0A`. | Confirmed as an OS pattern, but not a complete public API. |
+
+The raw FIFO sequence is only the byte layer. A working transfer still needs the packet layer:
+machine ID, command, length, payload checksum, ACK/NAK, and EOT. That framing is documented in
+[sub-link-transfer.md](sub-link-transfer.md#3-packet-framing--the-ti-link-protocol-c).
+
+Practical rules:
+
+- Set up `IY+0x1B` consistently before calling `_LinkXferOP`. Bit 0 is the USB-first selector.
+- Do not write ports `0x08`-`0x0D` while the OS link engine is active; the OS keeps state in
+  `IY+0x3E` bit 0, `0x9C86`, and `0x9CAC`.
+- If a custom interrupt handler is installed, either chain to the OS handler or service the same
+  source gates. The OS itself expects to handle port `0x55`/`0x56` events.
+- Treat any high-level USB endpoint/pipe controller claims as outside this page's confirmed scope.
+  This ROM pass does not trace a general USB host/device stack.
+
+## Open pieces
+
+- The target at `ram:2E48`, called from `_LinkXferOP` after the port `0x4D` line-state test, is not
+  a normal function in the current Ghidra database. A raw `z80dasm` window around `2E48` does not
+  decode as a clean routine body, so its exact side effects remain open. [hypothesis]
+- Port `0x0A` is confirmed as the assist RX/data read register on this path, but its initialization
+  value `0xB4` and the paired writes to `0x0B`/`0x0C` still need bit-level interpretation.
+  [hypothesis]
+- A future pass should trace the EasyData/USB app paths and reconcile any endpoint/pipe ports with
+  the OS 2.55MP database. [hypothesis]

--- a/tools/ports.txt
+++ b/tools/ports.txt
@@ -7,6 +7,11 @@
 06	port_mapBankA
 07	port_mapBankB
 08	port_linkAssist
+09	port_linkAssistStatus
+0A	port_linkAssistData
+0B	port_linkAssistConfigB
+0C	port_linkAssistConfigC
+0D	port_linkAssistTxFifo
 0F	port_0F
 10	port_lcdCmd
 11	port_lcdData
@@ -20,5 +25,6 @@
 35	port_timer2Status
 36	port_timer2Counter
 37	port_37
-55	port_intStatusExt
-56	port_intMaskExt
+4D	port_usbLineState
+55	port_usbIntStatus
+56	port_usbLineEvents


### PR DESCRIPTION
## Summary
- add a ROM-grounded USB ASIC/link-assist deep dive
- document observed assist FIFO ports, `_LinkXferOP` USB selection, and ISR assist handling
- cross-link the new page from the mdBook summary, overview, memory map, keyboard/link, and link-transfer docs
- update local port labels for confirmed assist/USB status ports

## Verification
- `git diff --cached --check` before commit
- `nix shell nixpkgs#mdbook nixpkgs#mdbook-mermaid -c mdbook build` after copying ignored local web assets from the main checkout into this worktree
- raw ROM windows checked with `z80dasm` for `3C:6BB1`, `3C:6BF4`, `3C:6C31`, `3C:6C81`, `3C:6D41`, and `00:01B1`

## Caveats
- the page intentionally avoids relying on WikiTI as proof; external names are only orientation
- `ram:2E48` remains unresolved because the current Ghidra DB does not expose it as a normal function and raw decode does not form a clean routine body
- port `0x0A`/`0x0B`/`0x0C` initialization bit meanings remain open
