### PR TITLE
Add GitHub Pages previews for PRs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,37 +6,50 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
-# Allow one concurrent deployment; don't cancel an in-progress production deploy.
+# Serialize writes to the gh-pages branch with PR preview deployments.
 concurrency:
-  group: pages
+  group: github-pages-branch
   cancel-in-progress: false
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v16
       - name: Build the mdBook wiki (mdBook + mermaid + KaTeX + pseudocode.js)
         run: nix build .#default -L
-      - name: Stage site
+      - name: Deploy production site
         run: |
-          mkdir -p _site
-          cp -rL result/. _site/
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: _site
+          set -euo pipefail
 
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@v4
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          site="$(mktemp -d)"
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            git fetch origin gh-pages
+            git worktree add "$site" origin/gh-pages
+          else
+            git worktree add --detach "$site"
+            git -C "$site" checkout --orphan gh-pages
+            git -C "$site" rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          mkdir -p "$site/pr"
+          find "$site" -mindepth 1 -maxdepth 1 \
+            ! -name ".git" \
+            ! -name "pr" \
+            -exec rm -rf {} +
+          cp -rL result/. "$site/"
+          touch "$site/.nojekyll"
+
+          git -C "$site" add -A
+          if git -C "$site" diff --cached --quiet; then
+            echo "No Pages changes to deploy."
+          else
+            git -C "$site" commit -m "Deploy production Pages site"
+            git -C "$site" push origin HEAD:gh-pages
+          fi

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,130 @@
+name: Deploy PR preview to GitHub Pages
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Serialize writes to the gh-pages branch with production deployments.
+concurrency:
+  group: github-pages-branch
+  cancel-in-progress: false
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - name: Build the mdBook wiki (mdBook + mermaid + KaTeX + pseudocode.js)
+        run: nix build .#default -L
+      - name: Deploy preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          site="$(mktemp -d)"
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            git fetch origin gh-pages
+            git worktree add "$site" origin/gh-pages
+          else
+            git worktree add --detach "$site"
+            git -C "$site" checkout --orphan gh-pages
+            git -C "$site" rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          preview_dir="$site/pr/$PR_NUMBER"
+          rm -rf "$preview_dir"
+          mkdir -p "$preview_dir"
+          cp -rL result/. "$preview_dir/"
+          touch "$site/.nojekyll"
+
+          git -C "$site" add -A
+          if git -C "$site" diff --cached --quiet; then
+            echo "No preview changes to deploy."
+          else
+            git -C "$site" commit -m "Deploy PR #$PR_NUMBER preview"
+            git -C "$site" push origin HEAD:gh-pages
+          fi
+      - name: Comment preview URL
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          PREVIEW_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr/${{ github.event.pull_request.number }}/
+        run: |
+          set -euo pipefail
+
+          marker="<!-- ti84-re-pages-preview -->"
+          body="$marker
+          GitHub Pages preview: $PREVIEW_URL"
+
+          comment_id="$(
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+              --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$marker\"))) | .id" \
+              | tail -n 1
+          )"
+
+          if [ -n "$comment_id" ]; then
+            gh api "repos/$REPO/issues/comments/$comment_id" \
+              --method PATCH \
+              --field body="$body" >/dev/null
+          else
+            gh pr comment "$PR_NUMBER" --body "$body"
+          fi
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Remove preview
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if ! git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            echo "No gh-pages branch exists; nothing to clean."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          site="$(mktemp -d)"
+          git fetch origin gh-pages
+          git worktree add "$site" origin/gh-pages
+
+          rm -rf "$site/pr/$PR_NUMBER"
+          git -C "$site" add -A
+          if git -C "$site" diff --cached --quiet; then
+            echo "No preview directory to remove."
+          else
+            git -C "$site" commit -m "Remove PR #$PR_NUMBER preview"
+            git -C "$site" push origin HEAD:gh-pages
+          fi
+
+          marker="<!-- ti84-re-pages-preview -->"
+          comment_id="$(
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+              --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$marker\"))) | .id" \
+              | tail -n 1
+          )"
+
+          if [ -n "$comment_id" ]; then
+            gh api "repos/$REPO/issues/comments/$comment_id" \
+              --method PATCH \
+              --field body="$marker
+              GitHub Pages preview removed because this PR is closed." >/dev/null
+          fi


### PR DESCRIPTION
## Summary
- publish production mdBook builds to the `gh-pages` branch root
- add PR preview deployments under `gh-pages/pr/<number>/`
- post or update a bot comment with the preview URL
- clean up each preview directory when its PR closes

## Verification
- `nix shell nixpkgs#actionlint -c actionlint`
- `git diff --check`
- `git diff --cached --check`

## Notes
- GitHub Pages is currently configured as `main /` (`gh api repos/siraben/ti84p-re/pages`). After this merges, switch the Pages source to `gh-pages /` so URLs like `https://siraben.github.io/ti84p-re/pr/123/` serve the preview directories.
- PR previews from forks may not be able to push with the default `pull_request` token permissions; this keeps the workflow safer than `pull_request_target`.
