### PR TITLE
Investigate RAM page 83 usage

### DIFF
--- a/docs/14-ram-pages.md
+++ b/docs/14-ram-pages.md
@@ -2,8 +2,9 @@
 
 The TI-84 Plus has banked RAM pages behind the Z80's 16 KiB windows. TI-OS normally
 keeps RAM page `81` in `8000-BFFF` and RAM page `80` in `C000-FFFF`, but ROM helpers
-temporarily map other pages for paged memory access. Page `83` is not free scratch on
-OS 2.55MP: the OS and MathPrint-era homescreen code use parts of it.
+temporarily map other pages for paged memory access. On OS 2.55MP, traces show page
+`83` writes during boot/home initialization and during homescreen expression entry.
+Programs that borrow page `83` must preserve or restore the OS-visible regions below.
 
 ## Page selectors [confirmed]
 
@@ -37,14 +38,15 @@ normal OS execution.
 
 WikiTI's [RAM pages](https://wikiti.brandonw.net/index.php?title=83Plus:OS:Ram_Pages)
 page is a useful public map, but OS 2.55MP needs the page-`83` warnings to be read
-literally. The local trace and disassembly support this table:
+literally. The local dump at `wikiti-dump/main/83Plus:OS:Ram Pages.wiki` carries
+the same current page-`83` notes. The local trace and disassembly support this table:
 
 | RAM page | Use |
 |----------|-----|
 | `80` | Normal `C000-FFFF` RAM page. The boot/home trace restores this with `OUT (5),0`. WikiTI marks it execution-protected. |
 | `81` | Normal `8000-BFFF` RAM page. This contains the visible TI-OS RAM variables, OP registers, flags, graph buffers, user heap, and VAT window documented in `tools/ram.txt` and `ti83plus.inc`. |
 | `82` | Not a general OS work page under normal execution. The idle trace maps it briefly through port `5` as part of a paged RAM helper, then restores page `80`. WikiTI marks it execution-protected. |
-| `83` | Shared scratch/state page. WikiTI lists app-launch bytes, USB communication buffers, MathPrint homescreen history, and a homescreen graph buffer. OS 2.55MP also maps it dynamically through port `7` in the idle trace. |
+| `83` | Shared OS scratch/state page. OS 2.55MP maps it through port `6` for block copies and LCD capture, and through port `7` for a paged byte-store helper. Homescreen expression entry writes the previous-entry buffer at `577E`. |
 | `84` | Not used by TI-OS under typical execution; WikiTI marks it execution-protected. |
 | `85` | Not used by TI-OS under typical execution on full-RAM hardware. |
 | `86` | Not used by TI-OS under typical execution; WikiTI marks it execution-protected. |
@@ -55,46 +57,140 @@ WikiTI's [port `15`](https://wikiti.brandonw.net/index.php?title=83Plus:Ports:15
 identifies ASIC value `55h` as the 48 KiB TA1 ASIC. Programs that use page `83` must not
 treat `82-87` as independent storage on that hardware. **[standard]**
 
-## Page `83` [confirmed and standard]
+## Per-page trace coverage [confirmed]
 
-Page `83` is the page people most often borrow as scratch, but it has OS-visible state:
+The boot/home and `2+3 ENTER` traces exercise startup, homescreen initialization,
+display capture, parsing, evaluation, and previous-entry storage. They do not exercise
+app launch, USB transfer, graph drawing, archive cleanup, or a 48 KiB ASIC. Within
+that scope, physical RAM-page writes are:
+
+| RAM page | Idle trace writes | `2+3 ENTER` trace writes | Interpretation |
+|----------|-------------------|--------------------------|----------------|
+| `80` | `256227` writes, all page addresses touched | `345702` writes, all page addresses touched | Normal high RAM page selected by port `5`; contains stack/system/user RAM activity in the `C000-FFFF` window. |
+| `81` | `62947` writes, all page addresses touched | `72638` writes, all page addresses touched | Normal `8000-BFFF` RAM page; contains the documented OS variables, flags, OP registers, heap, VAT window, and working buffers. |
+| `82` | no writes observed | no writes observed | Port `5` briefly selects raw value `02`, but the observed store is through page `83` in bank B. No page-`82` storage is confirmed by these traces. |
+| `83` | `1882` writes to `43D9-44BD` and `5A7E-5DF2` | `3467` writes to `4373-4390`, `43D9-44BD`, `577E-5790`, and `5A7E-5DF2` | Shared OS scratch/state page. See the range table below. |
+| `84` | no writes observed | no writes observed | No typical-use OS storage confirmed in these traces. |
+| `85` | no writes observed | no writes observed | No typical-use OS storage confirmed in these traces. |
+| `86` | no writes observed | no writes observed | No typical-use OS storage confirmed in these traces. |
+| `87` | no writes observed | no writes observed | No typical-use OS storage confirmed in these traces. |
+
+The zero-write rows mean "not hit by these scenarios," not a global proof that the
+page is never used. On 48 KiB hardware, pages `82-87` alias page `83`, so writes
+intended for `84-87` would not be independent storage even if a program can select
+those page numbers. **[standard]**
+
+The graph scenario in `tools/macros/graph-y1-x2.macro` reaches the graph screen and
+still only writes pages `80`, `81`, and `83`. It increases normal page-`80`/`81`
+activity but leaves page-`83` at the same confirmed ranges as the idle trace.
+It does not hit pages `82` or `84-87`. **[confirmed]**
+
+## How to hit the confirmed paths
+
+The useful distinction is between "page number can be selected" and "the OS uses it
+in a normal workflow." These paths are confirmed or have a concrete next scenario:
+
+| Page/path | How to hit it | Evidence |
+|-----------|---------------|----------|
+| `80` high RAM | Run any cold-boot, home, expression, or graph trace. | Port `5 = 00` is the normal restore value; every current trace writes all page-`80` addresses. **[confirmed]** |
+| `81` normal bank-B RAM | Run any cold-boot, home, expression, or graph trace. | Port `7 = 81` is the normal restore value; every current trace writes all page-`81` addresses. **[confirmed]** |
+| `83` display capture | Run `boot-idle.macro` or `graph-y1-x2.macro`. | Ghidra shows `_SaveDisp` at `39:5E03` calls `lcd_read_block` at `ram:1890`; coverage hits both, and writes `5A7E-5DF2`. **[confirmed]** |
+| `83` homescreen previous-entry history | Run `home-2plus3.macro`. | The trace adds `577E-5790`, advances `lastEntryPTR` from `577E` to `5791`, and sets `numLastEntries` to `01`. **[confirmed]** |
+| `83` expression scratch copy | Run `home-2plus3.macro`. | The trace adds `4373-4390` through `flash_copy_block` at `ram:1868`/`ram:187C`. **[confirmed]** |
+| `83` split-screen/table copy | Enter a split-screen/table workflow that calls `_ScreenSplit`. | Ghidra shows `_ScreenSplit` at `05:7712` calls `flash_copy_block` at `05:772A`; this path is not hit by the current macros. **[confirmed]** |
+| `83` edit-buffer initialization | Enter an edit-buffer workflow that reaches `editbuf_init_buf`. | Ghidra shows `editbuf_init_buf` at `03:6BC4` calls `flash_copy_block` at `03:6BCD`; this path is not hit by the current macros. **[confirmed]** |
+| `83` app-menu state restore | Open an app/menu workflow that reaches `mnu_restore_app_state`. | Ghidra shows `mnu_restore_app_state` at `39:6D96` calls `flash_copy_block` at `39:6DA0`; this path is not hit by the current macros. **[confirmed]** |
+| `84-87` independent pages | Use a forced RAM-page probe or a ROM path that passes pair index `2` or `3` to the computed bank-pair helper. | The ROM can compute these selectors, but raw immediate selector scans and current traces do not show a normal OS path selecting or writing them. **[hypothesis]** |
+
+The computed bank-pair helpers use this selector formula:
+
+```z80
+    ld a,b
+    sla a
+    out (5),a        ; pair index 0/1/2/3 -> pages 80/82/84/86 in bank C
+    inc a
+    or 80h
+    out (7),a        ; pair index 0/1/2/3 -> pages 81/83/85/87 in bank B
+```
+
+The direct callers decoded so far set `B = 1`, which selects pages `82/83`. That
+explains the observed `port 5 = 02`, `port 7 = 83` sequence and why no current
+trace writes page `84-87`. A targeted probe for pages `84-87` should either run
+small RAM code that writes selectors `84h-87h` directly, or find a UI path that
+passes `B = 2` or `B = 3` into this helper. The `B = 1` caller pattern is
+confirmed for the decoded callers above. **[confirmed]**
+
+## Page `83` use [confirmed and standard]
+
+Page `83` is the page people most often borrow as scratch, but the ROM uses it as
+more than anonymous free RAM. Keep the evidence classes separate:
 
 | Range | Use | Evidence |
 |-------|-----|----------|
-| `4008-4080` | App base-page staging before app execution | WikiTI public note; regenerated by the OS before app launch. |
-| `4100-433A` | USB communication buffers | WikiTI public note; this project has not yet isolated the live USB buffer trace. |
-| `577E-5A7D` | MathPrint-era previous-entry history | WikiTI public note; OS 2.55MP references `577E`, `5A7E`, `lastEntryPTR` (`8DA7`), and `numLastEntries` (`8E29`) in the homescreen/history routines on pages `33`, `37`, and `38`. |
-| `5A7E-5D7D` | Homescreen graph buffer | WikiTI public note; adjacent to the previous-entry buffer and referenced by page-`33` history code. |
-| offset `04BD` | Idle-trace byte store through RAM page `83` | Dynamic trace maps `port 7 = 83`, stores at logical `84BD`, then restores `port 7 = 81` and `port 5 = 00`. |
+| `4373-4390` | Expression-path page-`83` scratch copy | Added by the `2+3 ENTER` trace. The write PC is the page-`83` block-copy helper at `ram:187C`/`ram:187E`; the caller is still unlabeled. **[confirmed]** |
+| `43D9-44BD` | Boot/home page-`83` scratch copy | Present in the idle trace. The write PC is the page-`83` block-copy helper at `ram:187C`/`ram:187E`, plus one byte through `37:44D7`. **[confirmed]** |
+| `577E-5A7D` | Homescreen previous-entry history | Page `33` references `577E`, the `5A7E` upper bound, `lastEntryPTR` (`0x8DA7`), and `numLastEntries` (`0x8E29`). The `2+3 ENTER` trace writes `577E-5790`, advances `lastEntryPTR` to `5791`, and sets `numLastEntries` to `01`. **[confirmed]** |
+| `5A7E-5DF2` | LCD/home display capture area | Present in the idle trace. Ghidra decompiles `ram:1890` as an LCD-read helper that maps page `83` through port `6` and stores bytes read from LCD port `11`. **[confirmed]** |
+| `4008-4080` | App base-page staging before app execution | WikiTI public note; the two traces on this page do not launch an app. **[standard, not traced here]** |
+| `4100-433A` | USB communication buffers | WikiTI public note; the two traces on this page do not exercise USB transfer. **[standard, not traced here]** |
 
-The reset path on page `37` initializes the history pointers for MathPrint-era state:
+Ghidra identifies the page-`83` block-copy helper at `ram:1868`. It saves the current
+port-`6` value, writes `83h` to port `6`, runs `LDIR`, and restores the previous page
+through the page-set helper:
 
 ```z80
-37:6E13  LD HL,577Eh
-37:6E16  LD (lastEntryPTR),HL
-37:6E19  LD HL,0000h
-37:6E1C  LD (numLastEntries),HL
+ram:1877  IN A,(6)
+ram:1879  PUSH AF
+ram:187A  LD A,83h
+ram:187C  OUT (6),A
+ram:187E  LDIR
+ram:1880  POP AF
+ram:1881  CALL 181Ch
+```
+
+Ghidra identifies the LCD capture helper at `ram:1890`. It maps page `83`, waits on
+the LCD, reads port `11`, and stores each byte through `HL`:
+
+```z80
+ram:189F  IN A,(6)
+ram:18A1  PUSH AF
+ram:18A2  LD A,83h
+ram:18A4  OUT (6),A
+ram:18A6  CALL 0CC3h
+ram:18A9  IN A,(11h)
+ram:18AB  LD (HL),A
+```
+
+The reset path on page `37` initializes the previous-entry pointers:
+
+```z80
+37:6E0D  LD HL,577Eh
+37:6E10  LD (lastEntryPTR),HL
+37:6E13  LD HL,0000h
+37:6E16  LD (numLastEntries),HL
 ```
 
 Page `38` has a second clear path with the same pointer reset:
 
 ```z80
-38:422E  LD HL,577Eh
-38:4231  LD (lastEntryPTR),HL
-38:4234  LD HL,0000h
-38:4237  LD (numLastEntries),HL
+38:422D  LD HL,577Eh
+38:4230  LD (lastEntryPTR),HL
+38:4233  LD HL,0000h
+38:4236  LD (numLastEntries),HL
 ```
 
-The homescreen entry-history code on page `33` uses the same boundary constants:
+The homescreen entry-history code on page `33` uses the same constants and variables:
 
 ```z80
-33:53D2  LD A,(numLastEntries)
-33:53E3  LD HL,5A7Eh
-33:53F8  LD HL,577Eh
-33:5431  LD A,(numLastEntries)
-33:543B  LD HL,577Eh
+33:53D1  LD A,(numLastEntries)
+33:53E2  LD HL,5A7Eh
+33:53F7  LD HL,577Eh
+33:5430  LD A,(numLastEntries)
+33:543A  LD DE,577Eh
 33:5452  LD HL,577Eh
-33:5480  LD HL,numLastEntries
+33:5459  LD (lastEntryPTR),HL
+33:5462  LD HL,numLastEntries
+33:5465  INC (HL)
 ```
 
 If a program modifies the history buffer on page `83`, clearing `numLastEntries`
@@ -102,9 +198,63 @@ at `8E29` prevents the homescreen from scrolling back into invalid entry data.
 That is the public WikiTI recovery advice, and the ROM confirms that `8E29` is
 the OS-visible previous-entry count. **[standard, address confirmed]**
 
+## Dynamic test scenarios
+
+The trace analyzer maps TilEm memory-write records back to physical RAM pages. Use
+it with full-range traces:
+
+```sh
+ROM=/path/to/ti84plus_2.55mp_complete.rom
+tilem2 --headless --rom "$ROM" --model ti84p --normal-speed --reset \
+  --macro tools/macros/boot-idle.macro \
+  --trace /tmp/page83-idle.trace --trace-range all
+tilem2 --headless --rom "$ROM" --model ti84p --normal-speed --reset \
+  --macro tools/macros/home-2plus3.macro \
+  --trace /tmp/page83-2plus3.trace --trace-range all
+tilem2 --headless --rom "$ROM" --model ti84p --normal-speed --reset \
+  --macro tools/macros/graph-y1-x2.macro \
+  --trace /tmp/page83-graph.trace --trace-range all
+python3 tools/analyze_ram_page_trace.py /tmp/page83-idle.trace --page 0x83
+python3 tools/analyze_ram_page_trace.py /tmp/page83-2plus3.trace --page 0x83
+python3 tools/analyze_ram_page_trace.py /tmp/page83-graph.trace --page 0x83
+```
+
+The baseline idle trace writes:
+
+```text
+RAM page 0x83 writes: 1882
+unique page addresses: 1114
+range 43D9-44BD
+range 5A7E-5DF2
+```
+
+The `2+3 ENTER` trace writes:
+
+```text
+RAM page 0x83 writes: 3467
+unique page addresses: 1163
+range 4373-4390
+range 43D9-44BD
+range 577E-5790
+range 5A7E-5DF2
+```
+
+The before/after RAM variables line up with the previous-entry write:
+
+| Scenario | `lastEntryPTR` (`0x8DA7`) | `numLastEntries` (`0x8E29`) |
+|----------|---------------------------|-----------------------------|
+| Idle home screen | `577E` | `00` |
+| After `2+3 ENTER` | `5791` | `01` |
+
+Those values come from end-of-trace RAM reconstruction. The added page-`83` range
+`577E-5790` is exactly the bytes between the old and new `lastEntryPTR` values.
+**[confirmed]**
+
 ## Restoring after page `83`
 
-For code entered from normal TI-OS state, restore the two RAM windows this way:
+Restore the selector for every window you changed. For code entered from normal TI-OS
+state that temporarily maps page `83` into bank B (`8000-BFFF`) and page `82` into
+bank C (`C000-FFFF`), restore the two RAM windows this way:
 
 ```z80
     ld a,$81
@@ -113,13 +263,30 @@ For code entered from normal TI-OS state, restore the two RAM windows this way:
     out (5),a        ; C000-FFFF back to RAM page 80
 ```
 
-Keep the nonstandard mapping inside a short critical section. The OS helper preserves
-interrupt state around the temporary RAM-page mapping so the interrupt handler does not
-run with bank B pointing at page `83`.
-
-For code that may be called with nonstandard paging, preserve and restore the selectors:
+For code that maps page `83` into bank A (`4000-7FFF`), preserve and restore port `6`:
 
 ```z80
+    in a,(6)
+    push af
+
+    ld a,$83
+    out (6),a        ; map RAM page 83 at 4000-7FFF
+    ; use 4000-7FFF here
+
+    pop af
+    out (6),a        ; restore previous Flash/RAM page selector
+```
+
+Keep the nonstandard mapping inside a short critical section. The OS helper preserves
+interrupt state around the temporary RAM-page mapping so the interrupt handler does not
+run with bank A or bank B pointing at page `83`.
+
+For code that may be called with nonstandard paging, preserve and restore the selectors
+for all touched windows:
+
+```z80
+    in a,(6)
+    push af
     in a,(7)
     push af
     in a,(5)
@@ -133,6 +300,8 @@ For code that may be called with nonstandard paging, preserve and restore the se
     out (5),a
     pop af
     out (7),a
+    pop af
+    out (6),a
 ```
 
 The OS's own paged byte-store helper at `37:44AE` uses the normal restore pattern:

--- a/tools/analyze_ram_page_trace.py
+++ b/tools/analyze_ram_page_trace.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Summarize TilEm memory-write records for one physical RAM page.
+
+Capture with ``tilem2 --trace TRACE --trace-range all``. The trace contains
+logical write addresses, so this tool replays page-select OUT instructions and
+maps each write back to the physical RAM page selected for that 16 KiB window.
+"""
+import argparse
+from collections import Counter, defaultdict
+import sys
+
+from tilem_trace_resolve import (
+    IDX_PC,
+    Banker,
+    fmt_addr,
+    iter_records,
+    read_header,
+)
+
+
+WINDOW_BASE = {
+    1: 0x4000,
+    2: 0x8000,
+    3: 0xC000,
+}
+
+
+def parse_int(value):
+    return int(value, 0)
+
+
+def map_ram_write(banker, logical):
+    region = logical >> 14
+    if region == 0:
+        return None
+    if region == 1:
+        kind, page = banker.bank_page(6, banker.bank_a)
+    elif region == 2:
+        kind, page = banker.bank_page(7, banker.bank_b)
+    else:
+        kind, page = banker.bank_page(5, banker.bank_c)
+    if kind != "ram" or page is None:
+        return None
+    return page, logical - WINDOW_BASE[region], region
+
+
+def ranges_for(offsets):
+    if not offsets:
+        return []
+    ordered = sorted(offsets)
+    ranges = []
+    start = prev = ordered[0]
+    for off in ordered[1:]:
+        if off == prev + 1:
+            prev = off
+            continue
+        ranges.append((start, prev))
+        start = prev = off
+    ranges.append((start, prev))
+    return ranges
+
+
+def fmt_page_addr(offset):
+    return f"{0x4000 + offset:04X}"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("trace", help="TilEm trace captured with --trace-range all")
+    ap.add_argument("--page", type=parse_int, default=0x83,
+                    help="physical RAM page to summarize (default: 0x83)")
+    ap.add_argument("--events", action="store_true",
+                    help="print every matching memory-write event")
+    ap.add_argument("--limit", type=int, default=0,
+                    help="maximum event rows to print with --events")
+    ap.add_argument("--resync", action="store_true",
+                    help="skip partial records in ring-buffer traces")
+    args = ap.parse_args()
+
+    banker = Banker()
+    writes = defaultdict(lambda: {"count": 0, "first": None, "last": None,
+                                  "values": Counter(), "pcs": Counter()})
+    events = []
+    instr_idx = 0
+    last_pc = None
+    last_resolved = None
+    matched = 0
+
+    with open(args.trace, "rb") as fp:
+        hdr = read_header(fp)
+        if hdr["range_start"] != 0 or hdr["range_end"] != 0xFFFF:
+            print("warning: trace was not captured with --trace-range all",
+                  file=sys.stderr)
+
+        for rtype, payload in iter_records(fp, resync=args.resync):
+            if rtype == 0x01:
+                last_pc = payload[IDX_PC]
+                banker.feed(payload)
+                space, gaddr, _, _ = banker.resolve(last_pc)
+                last_resolved = (space, gaddr)
+                instr_idx += 1
+                continue
+            if rtype != 0x02:
+                continue
+
+            logical, value = payload
+            mapped = map_ram_write(banker, logical)
+            if mapped is None:
+                continue
+            page, offset, region = mapped
+            if page != args.page:
+                continue
+
+            ent = writes[offset]
+            ent["count"] += 1
+            ent["first"] = instr_idx if ent["first"] is None else ent["first"]
+            ent["last"] = instr_idx
+            ent["values"][value] += 1
+            if last_resolved is not None:
+                ent["pcs"][last_resolved] += 1
+
+            matched += 1
+            if args.events and (args.limit == 0 or len(events) < args.limit):
+                events.append((instr_idx, logical, value, offset, region,
+                               last_pc, last_resolved))
+
+    print(f"RAM page 0x{args.page:02X} writes: {matched}")
+    print(f"unique page addresses: {len(writes)}")
+    for start, end in ranges_for(writes):
+        if start == end:
+            print(f"range {fmt_page_addr(start)}")
+        else:
+            print(f"range {fmt_page_addr(start)}-{fmt_page_addr(end)}")
+
+    if writes:
+        print("\nTop write PCs:")
+        pc_counts = Counter()
+        for ent in writes.values():
+            pc_counts.update(ent["pcs"])
+        for (space, addr), count in pc_counts.most_common(12):
+            print(f"{count:6d}  {fmt_addr(space, addr)}")
+
+    if args.events:
+        print("\nEvents:")
+        for instr_idx, logical, value, offset, region, pc, resolved in events:
+            pc_s = "unknown"
+            if resolved is not None:
+                pc_s = fmt_addr(*resolved)
+            print(f"{instr_idx:9d}  logical={logical:04X}  "
+                  f"page_addr={fmt_page_addr(offset)}  value={value:02X}  "
+                  f"window={region}  pc={pc_s}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/dynamic-tracing.md
+++ b/tools/dynamic-tracing.md
@@ -80,6 +80,9 @@ tools/tilem_trace_resolve.py /tmp/b.trace --print 40 --names tools/names.txt
 # every bank switch (port 5 / port 6 / port 7 writes)
 tools/tilem_trace_resolve.py /tmp/b.trace --page-switches
 
+# physical RAM page writes, after replaying port 5/6/7 page selection
+tools/analyze_ram_page_trace.py /tmp/b.trace --page 0x83
+
 # coverage: distinct executed addresses + hit counts
 tools/tilem_trace_resolve.py /tmp/b.trace --coverage --sort count --names tools/names.txt
 ```
@@ -157,7 +160,9 @@ rather than paged-address resolution.
 ## Files
 
 - [`tilem_trace_resolve.py`](tilem_trace_resolve.py) — trace → paged Ghidra address resolver.
+- [`analyze_ram_page_trace.py`](analyze_ram_page_trace.py) — trace memory writes → physical RAM page ranges.
 - [`macros/home-2plus3.macro`](macros/home-2plus3.macro) — power on, dismiss splash, evaluate `2+3`.
+- [`macros/graph-y1-x2.macro`](macros/graph-y1-x2.macro) — power on, enter `Y1=X^2`, and graph it.
 - [`macros/boot-idle.macro`](macros/boot-idle.macro) — baseline for coverage diffs.
 
 ## Trace format (quick reference)

--- a/tools/macros/graph-y1-x2.macro
+++ b/tools/macros/graph-y1-x2.macro
@@ -1,0 +1,22 @@
+# Power on, dismiss the RAM-cleared splash, enter Y1=X^2, and graph it.
+# Use this as a dynamic RAM-page scenario beyond the home-screen baseline:
+#   tilem2 --headless --rom "$ROM" --model ti84p --normal-speed --reset \
+#     --macro tools/macros/graph-y1-x2.macro \
+#     --trace /tmp/page83-graph.trace --trace-range all
+set key_hold 0.15s
+set key_delay 0.08s
+wait 4s
+key ON
+wait 3s
+key ENTER
+wait 1.5s
+key CLEAR
+key Y=
+wait 0.5s
+key CLEAR
+key GRAPHVAR
+key SQUARE
+wait 0.5s
+key GRAPH
+wait 4s
+screenshot /tmp/calc-graph-y1-x2.png


### PR DESCRIPTION
## Summary
- replace the broad page-83 scratch warning with confirmed ranges from static RE and dynamic traces
- add `tools/analyze_ram_page_trace.py` to replay TilEm trace banking and summarize physical RAM page writes
- document before/after scenarios for idle home versus `2+3 ENTER`, including the previous-entry buffer growth from `577E` to `5791`

## Evidence
- Ghidra decompiled `ram:1868` as the page-83 block-copy helper and `ram:1890` as the LCD-read helper
- `z80dasm` checked the page-37/page-38 reset paths, page-33 history routines, and page-0 helpers where Ghidra boundaries were incomplete
- dynamic traces show idle writes `43D9-44BD` and `5A7E-5DF2`; `2+3 ENTER` adds `4373-4390` and `577E-5790`

## Verification
- `python3 -m py_compile tools/analyze_ram_page_trace.py tools/tilem_trace_resolve.py`
- `python3 tools/analyze_ram_page_trace.py /tmp/page83-2plus3.trace --page 0x83`
- `git diff --check`
- `nix build`