### PR TITLE
Accuracy pass over the wiki articles (part 2)

### DIFF
--- a/docs/09-keyboard-link.md
+++ b/docs/09-keyboard-link.md
@@ -7,7 +7,7 @@
 The keypad is a matrix read through **port 1** (`port_keypad`): write a group-select mask, read back the active columns. The **interrupt** triggers periodic scans; the result is debounced into `kbdScanCode` (`0x843F`).
 
 - `_GetCSC` (`00:04B2`) — "Get Cursor/Scan Code": with interrupts masked, returns `kbdScanCode` and clears it (one key per call, no repeat). Raw scan codes (`skXxx`). **[confirmed]**
-- `_GetKey` (`06:491E`) — the cooked key API: blocks, handles **2nd/ALPHA** modifier state, key repeat, and APD; returns a `TIKeyCode` (`kXxx`, 642 values). Also runs the cursor blink. Drives menus/homescreen. **[confirmed entry; body large]**
+- `_GetKey` (`06:491E`) — the cooked key API: blocks, handles **2nd/ALPHA** modifier state, key repeat, and APD; returns a `TIKeyCode` (`kXxx`; a single byte, ~255 distinct values exposed under many named aliases). Also runs the cursor blink. Drives menus/homescreen. **[confirmed entry; body large]**
 - `_KeyToString` (`01:6D10`) — map a key code to its display token/string (for text entry).
 
 Scan codes (`skEnter`, hardware matrix position) differ from key codes (`kEnter`=5, post-modifier). `_GetCSC` returns the former; `_GetKey` the latter.
@@ -17,7 +17,10 @@ Scan codes (`skEnter`, hardware matrix position) differ from key codes (`kEnter`
 The low-level read primitive is `kbd_reset_port` (`ram:0480`): it writes a **group-select mask** to **port 1** (active-low — `0` bits select rows to drive), waits 4 `NOP`s for the lines to settle, reads the column bits back, then writes `0xFF` to release. (On 84+ hardware, `IN A,(0x02) bit7` + `IN A,(0x20)` gate the read against link/clock activity first.)
 
 ```z80
-0480: IN A,(0x2) ; AND 0x80          ; 84+ present? (else fall straight through)
+0480: PUSH AF                         ; save the group-select mask
+0481: IN A,(0x2) ; AND 0x80           ; 84+ present?
+0485: JR NZ,0x0497                    ; 84+: gate the read on link/clock first (IN A,(0x20))
+0487: POP AF                          ; restore the group-select mask
 0488: OUT (0x1),A                     ; A = group-select mask (active-low)
 048a: NOP×4                           ; let the matrix settle
 048e: IN A,(0x1) ; LD B,A             ; read columns (active-low: 0 = key down)
@@ -29,7 +32,7 @@ The scanner `kbd_scan_autorepeat` (`ram:0406`) walks the matrix one group at a t
 
 | port-1 mask (`C`) | group / key row driven |
 |-------------------|------------------------|
-| `0xFE` (bit0 low) | group 0 — **GRAPH / arrow keys** (and the special `0xF5/0xF3/0xFA/0xFC` direction codes) |
+| `0xFE` (bit0 low) | group 0 — **arrow keys** (`skDown`/`skLeft`/`skRight`/`skUp` = `0x01`–`0x04`; the special `0xF5/0xF3/0xFA/0xFC` direction codes). GRAPH is in group 6 (`skGraph`=`0x31`), not here. |
 | `0xFD` (bit1 low) | group 1 |
 | `0xFB` (bit2 low) | group 2 |
 | `0xF7` (bit3 low) | group 3 |
@@ -40,7 +43,7 @@ The scanner `kbd_scan_autorepeat` (`ram:0406`) walks the matrix one group at a t
 | `0x00` (all low) | "any key down?" probe used by `0x0406`'s initial `SUB A` call; selects all groups |
 | `0xFF` (all high) | release all groups after a read (`kbd_reset_port` writes this at `0491`) |
 
-**Forming a raw scan code.** For each driven group the routine reads the column byte, then finds the single low (pressed) column bit by an 8-iteration `RLA`/`DJNZ` loop (`0435`–`043C`) that counts the **cleared** (pressed, active-low) column bits into `E` (`RLA` → `JR C` skips `INC E` on a `1` bit, so only `0` bits are counted) and records the bit index in `L`. If exactly one key is down it builds the scan code as **`group × 8 + column_index`**, where `group` is the 0-based group from the table above. The code forms it at `0453: DEC A; RLA;RLA;RLA; ADD A,L`: the iteration counter in `A` is 1-based, so `DEC A` converts it to the 0-based `group`, the three `RLA`s multiply by 8, and `ADD A,L` adds the column index in `L`; it then returns the byte. multiple simultaneous keys set carry (`SCF` @ `0459`) so the press is rejected (debounce / ghost-key reject). The single resulting byte is the raw scan code that lands in `kbdScanCode` (`0x843F`), which `_GetCSC` (`00:04B2`) then reads-and-clears under `DI`. The scan-enable gate `BIT 0,(IY+0x2C)` @ `0415` lets the ISR/`_GetKey` path special-case the arrow group.
+**Forming a raw scan code.** For each driven group the routine reads the column byte, then finds the single low (pressed) column bit by an 8-iteration `RLA`/`DJNZ` loop (`0435`–`043C`) that counts the **cleared** (pressed, active-low) column bits into `E` (`RLA` → `JR C` skips `INC E` on a `1` bit, so only `0` bits are counted) and records the **1-based column position** (the loop counter `B`, which runs `8→1`) in `L`. If exactly one key is down it builds the scan code as **`group × 8 + L`** (`L` = `1…8`, the pressed column's bit index plus one), where `group` is the 0-based group from the table above. The code forms it at `0453: DEC A; RLA;RLA;RLA; ADD A,L`: the iteration counter in `A` is 1-based, so `DEC A` converts it to the 0-based `group`, the three `RLA`s multiply by 8, and `ADD A,L` adds the 1-based column position in `L`; it then returns the byte. multiple simultaneous keys set carry (`SCF` @ `0459`) so the press is rejected (debounce / ghost-key reject). The single resulting byte is the raw scan code that lands in `kbdScanCode` (`0x843F`), which `_GetCSC` (`00:04B2`) then reads-and-clears under `DI`. The scan-enable gate `BIT 0,(IY+0x2C)` @ `0415` lets the ISR/`_GetKey` path special-case the arrow group.
 
 ### 2nd / ALPHA modifier state machine [confirmed]
 
@@ -66,7 +69,7 @@ The low three bits of the same `IY+0x12` byte are `indicFlags` (bit 0 `indicRun`
 - **`[ALPHA]` while already in alpha** (`06:4BFD`) → in a lowercase-capable context (`IY+0x24` bit 3) and still uppercase, `SET shiftLwrAlph` (`06:4C0D`) cycles **upper → lower**; otherwise it cancels alpha. Repeated `[ALPHA]` walks uppercase → lowercase → off.
 - **`[2nd]` while in alpha** (`06:4C1D`) → `SET shift2nd` (`06:4C25`): a 2nd press stacks on top of alpha (alpha is retained).
 
-`shift2nd` clears the moment a 2nd-combo key is consumed (`06:4B87`), and the IM1 timer ISR also clears it at `ram:01E0` (`RES 3,(IY+0x12)`), so a pending `[2nd]` does not linger. `_GetKey` sets `shiftAlpha` and (on 2nd+ALPHA) `shiftALock` but reads neither to clear alpha — within `_GetKey`, alpha stays set until a later `[ALPHA]` press cancels it. The one-shot-versus-lock choice is left to the consuming editor, which reads `shiftALock` (bit 6) to decide whether to drop `shiftAlpha` after a single character.
+`shift2nd` clears the moment a 2nd-combo key is consumed (`06:4B87`), and the IM1 timer ISR also clears it at `ram:01E0` (`RES 3,(IY+0x12)`), so a pending `[2nd]` does not linger. `_GetKey` makes alpha **one-shot** itself: after an alpha-mode key is consumed it calls the page-0 helper `ram:04BF`, which clears `shiftAlpha` (`RES 4,(IY+0x12)`) **unless** `shiftALock` (bit 6) or `shiftKeepAlph` (bit 7) is set (`BIT 6 → RET NZ; BIT 7 → RET NZ; RES 4`). So a plain `[ALPHA]` shifts only the next key, while `[2nd]`+`[ALPHA]` — which sets `shiftALock` — keeps alpha across keys until a later `[ALPHA]` cancels it.
 
 ```mermaid
 stateDiagram-v2
@@ -76,14 +79,14 @@ stateDiagram-v2
     Second --> Idle: any key, 2nd-shifted then RES b3 @4B87
     Second --> AlphaLock: ALPHA, SET b6 @4B96 + b4 @4B9A
     Idle --> Alpha: ALPHA, SET b4 + RES b5 @4AE8
-    Alpha --> Alpha: letter, alpha code, b4 stays
+    Alpha --> Idle: letter, alpha code, then RES b4 @04BF (one-shot)
     Alpha --> AlphaLower: ALPHA, SET b5 @4C0D
     AlphaLower --> Idle: ALPHA, cancel @4C13
     AlphaLock --> AlphaLock: letter, alpha code, locked
     AlphaLock --> Idle: ALPHA, cancel
     Alpha --> AlphaSecond: 2nd, SET b3 @4C25
     AlphaLock --> AlphaSecond: 2nd, SET b3 @4C25
-    AlphaSecond --> Alpha: key, 2nd-shifted, RES b3 (b6 clear)
+    AlphaSecond --> Idle: key, 2nd-shifted, RES b3, RES b4 @04BF (b6 clear)
     AlphaSecond --> AlphaLock: key, 2nd-shifted, RES b3 (b6 set)
 ```
 
@@ -102,9 +105,9 @@ The 2.5 mm I/O link has two open-collector lines (tip/ring), driven via **port 0
 
 `_SendAByte` (`3C:420D`) shows both paths **[confirmed]**:
 - **Hardware-assisted** (when enabled): poll status `port 0x09` bit 5 (ready), then write the byte to `port 0x0D`; helper routines on page 3C manage the assist FIFO/timing.
-- **Legacy bit-bang**: to send a bit, pull one line low (`port_link = 1` for a 0-bit, `2` for a 1-bit), wait for the receiver to mirror it, release, wait for idle — with a timeout that raises `E_LnkErr` (`0x9F`, "ERR:LINK") via `_JErrorNo` on failure (matching [sub-link-transfer.md](sub-link-transfer.md)). Repeats per bit of the byte.
+- **Legacy bit-bang**: to send a bit, pull one line low (write `1` to `port_link` for a 0-bit, `2` for a 1-bit), wait for the receiver to mirror it, release, wait for idle — with a timeout that raises `E_LnkErr` (`0x9F`, "ERR:LINK") via `_JErrorNo` on failure (matching [sub-link-transfer.md](sub-link-transfer.md)). Repeats per bit of the byte.
 
-`_RecAByteIO` (`3C:443F`) is the matching receive. Higher-level link commands (`_CmdLoad`, variable transfer, plus screen-shot / remote-control commands) sit on top. (Note: the names `_CircCmd`/`_VertCmd` are documented in [sub-graphing.md](sub-graphing.md) as the graphing draw commands `Circle(` (`33:74CE`) and `Vertical` (`04:7955`); the link-layer command routines referenced here are distinct and were not separately traced — treat this as a [hypothesis].)
+`_RecAByteIO` (`3C:443F`) is the matching receive. Higher-level link commands (`_SendCmd` (bcall `4F3F`), variable transfer, plus screen-shot / remote-control commands) sit on top. (Note: the names `_CircCmd`/`_VertCmd` are documented in [sub-graphing.md](sub-graphing.md) as the graphing draw commands `Circle(` (`33:74CE`) and `Vertical` (`04:7955`); the link-layer command routines referenced here are distinct and were not separately traced — treat this as a [hypothesis].)
 
 ### Variable-transfer command/packet framing
 

--- a/docs/12-memory-management.md
+++ b/docs/12-memory-management.md
@@ -55,7 +55,7 @@ Archived vars are *appended* to Flash, which can't be overwritten in place, so d
 Flash is **erased** a sector at a time but **programmed byte-by-byte** (the page-3D writer at `3D:64AA` calls the single-byte bcall `_WriteAByte`, id `8021`), via low-level routines through the **flash-control port `0x14`** (see [Variables, Archive & Unarchive](sub-vat-archive.md)) **[partly confirmed]**:
 - Live MCP-confirmed page-3D anchors include `_FlashToRam` (`3D:6745`), `flash_program_buf` (`3D:678C`), `flash_erase_wait` (`3D:5ED3`), `flash_cmd_base` (`3D:738B`), and the status-bit helpers `flash_op_fd` (`3D:7C8F`), `flash_op_fb` (`3D:7C93`), `flash_op_fe` (`3D:7C97`).
 - Further page-3D flash routines at `3D:61AF`, `3D:6B9B`, `3D:64AA`, `3D:62C2`, and `3D:6413` are not yet named in the current DB and await a symbol pass.
-- Archive workers: `_Arc_Unarc` (`07:6248`) → `arc_ram_to_flash` (`07:61F4`) / `arc_flash_to_ram` (`07:6107`).
+- Archive workers: `_Arc_Unarc` (`07:6248`) → `arc_ram_to_flash` (`07:6107`, RAM→Flash) / `arc_flash_to_ram` (`07:61F4`, Flash→RAM). (`_Arc_Unarc` dispatches on the FindSym page byte `B`: `B==0`/in-RAM → `6107` archive, `B≠0`/in-Flash → `61F4` unarchive.)
 
 ## Resolved
 The `_FindSym` VAT walk is byte-verified in [Variables, Archive & Unarchive](sub-vat-archive.md). Flash write/erase and GC still need a current MCP-backed symbol pass to replace the older address/name map.

--- a/docs/sub-calculation.md
+++ b/docs/sub-calculation.md
@@ -52,7 +52,7 @@ operands, then do BCD mantissa work and renormalize. Result in `OP1`.
 |----|---------|------|-------|
 | `+` | `_FPAdd` | `ram:229E` (= **RST 30h**) | sign-magnitude BCD add; see [06-floating-point.md](06-floating-point.md). |
 | `−` | `_FPSub` | `ram:2297` | flips `OP2.type` bit7 then falls into the add path. |
-| `×` | `_FPMult` | `ram:238B` | `FUN_ram_250F` adds exponents (→ `_ErrOverflow` on carry past 0x7F), then digit-by-digit BCD multiply accumulating into OP3. |
+| `×` | `_FPMult` | `ram:238B` | `ram:250F` adds exponents (→ `_ErrOverflow` on carry past 0x7F), then digit-by-digit BCD multiply accumulating into OP3. |
 | `÷` | `_FPDiv` | `ram:2541` | `_CkOP2FP0` first → `_JError(0x82)` DIVIDE BY 0 if divisor 0; else restoring BCD long division. |
 | `1/x` | `_FPRecip` | `ram:253D` | sets `OP1=1` then enters the divide loop (same body as `_FPDiv`). |
 
@@ -64,7 +64,7 @@ Convenience / derived ops:
 - **Negation**: `_InvOP1S` `ram:24BD` (XOR OP1.type with 0x80, guarding against −0), `_InvOP2S` `ram:24CD`, `_InvOP1SC` `ram:24BA` (both). `_CkOP1Pos` `ram:1E5D` ANDs OP1.type with 0x80. [confirmed]
 
 ### Roots & integer parts [confirmed]
-- `_SqRoot` `page_02:6E38`: `_ErrD_OP1NotPos` (→ DOMAIN if negative/complex-real), `fp_clear_guard`, `_ZeroOP3`, then a **digit-by-digit BCD square-root extraction** loop (`FUN_ram_1C9C` trial-subtract + `FUN_ram_1D4A` compare, halving the exponent up front). Not Newton's method — classic long-hand sqrt.
+- `_SqRoot` `page_02:6E38`: `_ErrD_OP1NotPos` (→ DOMAIN if negative/complex-real), `fp_clear_guard`, `_ZeroOP3`, then a **digit-by-digit BCD square-root extraction** loop (`ram:1C9C` trial-subtract + `ram:1D4A` compare, halving the exponent up front). Not Newton's method — classic long-hand sqrt.
 - `_Int`/`_Intgr` `ram:2621`/`2263`: **floor**. `_Trunc` `ram:2279` drops the fractional part (toward zero); `_Intgr` truncates then subtracts 1 (`_Minus1` `ram:2294`) when the original was negative, giving true floor.
 - `_Frac` `ram:24E3`: fractional part = x − trunc(x); shifts mantissa by the exponent and keeps the low digits.
 - `_Round` / `_RndGuard` `ram:2623` / `page_02:6A57`: round to the active display-digit count; `_Round` is a thin `cross_page_jump` wrapper (body banked off page 0).
@@ -72,8 +72,8 @@ Convenience / derived ops:
 ---
 
 ## 3. Degree/radian & polar conversions [confirmed]
-- `_DToR` `ram:236B` (deg→rad): multiply OP1 by $\pi/180$ (`FUN_ram_235D` loads the constant) then normalize via `FUN_ram_249E`.
-- `_RToD` `ram:2374` (rad→deg): multiply by $180/\pi$ (`FUN_ram_2361`).
+- `_DToR` `ram:236B` (deg→rad): multiply OP1 by $\pi/180$ (`ram:235D` loads the constant) then normalize via `ram:249E`.
+- `_RToD` `ram:2374` (rad→deg): multiply by $180/\pi$ (`ram:2361`).
 - `_PToR` `page_02:50BD` polar→rectangular; pairs with the complex trig below.
 These constants are the BCD floats `π/180 = 1.745…e-2` and `180/π = 5.729…e1` noted in
 [06-floating-point.md](06-floating-point.md)'s constant scan.
@@ -126,7 +126,7 @@ the `_TenX` body at `page_02:7069`; the ln/e^x/sin-cos coefficient tables are on
 ### Inverse trig [confirmed]
 - `_ASinRad` `76DA`, `_ACosRad` `76C9`, `_ATanRad` `76CF`, `_ATan2Rad` `76D4`, plus the
   degree-mode `_ASin`/`_ACos`/`_ATan`/`_ATan2` at `76F1`/`76DF`/`76E9`/`7749`.
-- `_ASin`/`_ACos` call domain check `SUB_page_02:79D3`; **|arg| > 1 → `_ErrDomain`**.
+- `_ASin`/`_ACos` call domain check `page_02:79D3`; **|arg| > 1 → `_ErrDomain`**.
 - All inverse trig funnel into the shared **arctangent CORDIC engine** at `page_02:774B`
   (`B=0x20` seeds the octant/quadrant base written to `0x84A4`; the core is a base-10
   trial-subtract digit recurrence, not a fixed 32-step loop), with asin/acos expressed
@@ -154,14 +154,14 @@ digit string honoring the **MODE** screen (Normal/Sci/Eng, Float/Fix 0–9).
   - Reads the digit-count/mode flags from `(IY+0xc)` and the byte at `0x89FA` (active
     fixed/decimal-places setting; `(IX-1)` local holds the effective format byte).
   - Exponent thresholds drive Normal↔Sci switchover: it compares `OP1.exp` against `0x7D`/`0x7F`
-    (≈ the ±-exponent window) and renormalizes (`FUN_ram_1BE7`) to bring the value into the
+    (≈ the ±-exponent window) and renormalizes (`ram:1BE7`) to bring the value into the
     displayable mantissa range, bumping a digit counter. Negative sign decrements the leading
     column count (`DEC (IX-3)`).
 - `_FormEReal` `page_06:5799` — forces **scientific/E** notation by setting `0,(IY+0xc)` then calling `_FormReal`. [confirmed]
 - `_FormBase` `page_06:57C0` — integer formatting in a base; requires `_CkOP1Real` (→ DATA TYPE / DOMAIN on non-real). [confirmed]
 - `_FormDCplx` `page_06:59D3` — complex `a+bi` / `r∠θ` formatting (calls `_FormReal` twice). [standard]
 - Exponent ↔ ASCII helpers on page 0: `_ExpToHex` `ram:1E4E`, `_OP1ExpToDec` `ram:1E77`,
-  `_DecO1Exp` `ram:1E6F` (decrement exp), `FUN_ram_1BCB` (BCD-digit → value). [confirmed]
+  `_DecO1Exp` `ram:1E6F` (decrement exp), `ram:1BCB` (BCD-digit → value). [confirmed]
 - The formatted string is then drawn by `_DispOP1A` (`page_04:7844`) / homescreen put-string
   routines (see [08-display-lcd.md](08-display-lcd.md)).
 
@@ -199,7 +199,7 @@ which unwinds to the error context and shows the named message. The raiser clust
 
 **Where the calc engine raises what:**
 - `÷ 0`, `1/0`: `_FPDiv`/`_FPRecip` → `0x82` DIVIDE BY 0.
-- `×`/`10^x`/exponent overflow: `FUN_ram_250F` exponent-add → `0x81` OVERFLOW.
+- `×`/`10^x`/exponent overflow: `ram:250F` exponent-add → `0x81` OVERFLOW.
 - `√(neg)`, `ln/log(≤0)`, `asin/acos(|x|>1)`, `tan(π/2)`, |trig arg| ≳ 10^12: `0x84` DOMAIN.
 - Complex result requested in real mode: `0x87` NONREAL ANS (the `_CLN`/complex paths).
 
@@ -211,7 +211,7 @@ Arithmetic core (page 0): `_FPAdd 229E`, `_FPSub 2297`, `_FPMult 238B`, `_FPDiv 
 `_FPRecip 253D`, `_FPSquare 238A`, `_Cube 237D`, `_Times2 2282`, `_TimesPt5 2382`,
 `_InvSub 227D`, `_Int 2621`, `_Intgr 2263`, `_Trunc 2279`, `_Frac 24E3`, `_Round 2623`,
 `_InvOP1S 24BD`, `_InvOP2S 24CD`, `_InvOP1SC 24BA`, `_CkOP1Pos 1E5D`, `fp_clear_guard 2627`,
-`fpmul_expadd FUN_ram_250F`, `_DToR 236B`, `_RToD 2374`, `cross_page_jump 2B09`.
+`fpmul_expadd 250F`, `_DToR 236B`, `_RToD 2374`, `cross_page_jump 2B09`.
 
 Transcendentals (page 02): `_SqRoot 6E38`, `_LnX 6EFD`, `_LogX 6F16`, `_CLN 6CCA`,
 `_CLog 6CE7`, `pow_core 6D08`, `_EToX 705C`, `_TenX 7066`, `_SinCosRad 733E`, `_Sin 7342`,

--- a/docs/sub-equation-display.md
+++ b/docs/sub-equation-display.md
@@ -179,11 +179,13 @@ typedef struct {
 } EqDispTemplateDescriptor;
 ```
 
-The mapper at `39:683D` converts a descriptor cell to pixels:
+The mapper at `39:683D` converts a descriptor cell to pixels. The `+7` loop (`DEC B; ADD A,7`)
+builds the **high** byte and the `+(rowHeight+2)` loop builds the **low** byte; the caller stores
+`HL` to `penCol`(`0x86D7`, low→x) / `penRow`(`0x86D8`, high→y), so the two products land as:
 
-$$x = \mathit{base}_x + 7 \cdot \mathit{col}$$
+$$x\ (\mathit{penCol}) = \mathit{base}_x + \mathit{row} \cdot (\mathit{rowHeight} + 2)$$
 
-$$y = \mathit{base}_y + \mathit{row} \cdot (\mathit{rowHeight} + 2)$$
+$$y\ (\mathit{penRow}) = \mathit{base}_y + 7 \cdot \mathit{col}$$
 
 The known descriptors are:
 
@@ -408,7 +410,7 @@ measured-fraction path calls `eqdisp_draw_box_jp` with `0x85EE`. [confirmed]
 endpoint helper `39:6B1C` are named `eqdisp_decr_counters` /
 `eqdisp_advance_col6` in the symbol table, and the Ghidra *decompiler*
 mis-analyzes both (it shows bare decrement loops). The raw disassembly matches
-this page instead: `683D` does `A = base; loop: add a,7` (`x = base_x + 7·col`)
+this page instead: `683D` does `A = base; loop: add a,7` into the **high** byte (`y = base_y + 7·col` → `penRow`)
 and `6B1C` does `ld a,1Bh; … add a,7 (×n); add a,4` (`x_left = 0x1B + 7n`,
 `x_right = x_left + 4`). Trust `z80dasm` over the decompiler for these tight
 register-passing routines, as [the README](https://github.com/siraben/ti84p-re/blob/main/README.md) advises. [confirmed]

--- a/docs/sub-graphing.md
+++ b/docs/sub-graphing.md
@@ -27,7 +27,7 @@ These are the values the WINDOW editor writes and the grapher reads.
 | `0x8F74` | `Ymax` | top edge real Y |
 | `0x8F7D` | `Yscl` | Y tick spacing |
 | `0x8F86` | `ThetaMin` / `0x8F8F` `ThetaMax` / `0x8F98` `ThetaStep` | polar/parametric range |
-| `0x900D` | `XresO` | Xres (pixel step between plotted columns), used by `_XftoI` |
+| `0x900D` | `XresO` | Xres (pixel step between plotted columns) |
 | `0x9151` | `Xres_int` | integer copy of Xres |
 | `0x9152` | `deltaX` | **(Xmax−Xmin)/94** — real width of one pixel column |
 | `0x915B` | `deltaY` | **(Ymax−Ymin)/62** — real height of one pixel row |
@@ -96,11 +96,11 @@ X/Y shown at the bottom of the screen, and by DRAW commands that take pixel argu
 **`_GrBufClr`** (`04:6071`): clears the whole 0x300-byte buffer to 0 (a
 `LD (HL),0` + 0x2FF-byte propagate copy). [confirmed]
 
-**`_IOffset`** (`04:42B5`) computes the LCD controller address bytes for a pixel:
+**`_IOffset`** (`04:42B5`) computes the LCD controller address bytes for a pixel (inputs `B`=x, `C`=y):
 ```
-curY    = (y >> 3) | 0x20      ; LCD "set Z/row page" command (8-px rows)
-curXRow = (0x3F - x) | 0x80    ; LCD "set column" command, X mirrored
-returns (table_42E4)[y & 7]    ; the 1-of-8 bit mask within the byte
+(0x844F) = (x >> 3) | 0x20     ; LCD "set row page" command — the rotated TI panel pages by X
+(0x8451) = (0x3F - y) | 0x80   ; LCD "set column" command (Y, mirrored)
+returns (table_42E4)[x & 7]    ; the 1-of-8 bit mask within the byte (bit = x mod 8)
 ```
 This is the bridge from a `(x,y)` pixel to a byte+bit in the buffer and the matching LCD
 command bytes. [confirmed]
@@ -112,9 +112,10 @@ pixel; 1..3 select dotted/animated styles), clips against the X-offset (`XOffset
 buffer bounds (`_IBounds`), then OR/AND/XORs the mask from `_IOffset`. **`_PointOn`**
 (`04:4155`) is the plain set-pixel entry. [confirmed]
 
-**`_PixelTest`** (`04:79E7`): the `pxl-Test(` command — validates row<64/col<96
-(`pixWide_m_1`), maps split-screen offset, and returns whether that buffer pixel is on.
-`_ErrDomain` on out-of-range. [confirmed]
+**`_PixelTest`** (`04:79E7`): the `pxl-Test(` command — validates the row/col against the
+**current graph dimensions** `lcdTallP` (`0x8DA3`) and `pixWide_m_1` (`0x8DA5`) — 63 and 95 on a
+full screen, smaller when split — maps the split-screen offset, and returns whether that buffer
+pixel is on. `_ErrDomain` on out-of-range. [confirmed]
 
 ---
 
@@ -132,7 +133,8 @@ the "draw/dark" mode forced. [confirmed]
 **`_CLine`/`_CLineS`** (`33:6028`/`33:6034`) and **`_UCLineS`** (`33:6010`) — **coordinate**
 line: take real-coordinate endpoints, run them through the X/Y transforms (the SetXX/ftoI
 path), then call the integer line. The `S` variants take an explicit style/mode byte; the
-mode bit comes from `(IY+0x35) & 0x80` (split-screen flag). These back the `Line(`
+mode bit comes from `(IY+0x35) & 0x80` (`hookflags3` bit 7, the drawing-hook-active flag —
+not a split-screen flag). These back the `Line(`
 DRAW command at the math layer. [strong]
 
 ### Circle
@@ -154,19 +156,20 @@ Each DRAW menu command has a page-04 bcall handler that draws into `plotSScreen`
 |-------|------|---------|
 | `_HorizCmd` | `04:793E` | `Horizontal y` — draws a full-width horizontal line at real Y. See note below. |
 | `_VertCmd` | `04:7955` | `Vertical x` — draws a full-height vertical line at real X. See note below. |
-| `_LineCmd` | `04:796A` | `Line(x1,y1,x2,y2)` — `_PDspGrph` then draws; checks pen, allocs 0x24-byte FPS for the 4 coords. |
+| `_LineCmd` | `04:796A` | `Line(x1,y1,x2,y2)` — `_PDspGrph`, optionally draws via page 33, then `JP 0x152A` = `_DeallocFPS1(0x24)` frees the coord frame (the alloc happens upstream). |
 | `_UnLineCmd` | `04:797C` | `Line(…,0)` — erase variant (same path, clear mode). |
 | `_PointCmd` | `04:79B2` | `Pt-On/Pt-Off/Pt-Change(` — reads style from `OP1.mantissa[0] & 0x20`, dispatches set/clear/toggle. |
 | `_DrawCmd` | `04:7B8B` | top-level `DRAW` dispatch — grabs the pending count and cross-jumps to the per-command handler. |
 | `_DrawZeroOP1` | `04:620B` | seeds OP3=0 then draws (used for axis / `DrawF` zero baseline). |
 
-Note: `_HorizCmd`/`_VertCmd` both `CALL 7933` first, which allocs a 0x24-byte FPS frame and
-saves the live window block (`1537`/`SBC HL,DE` pointer math). `_HorizCmd` then writes the
-line's Y coordinate into **both `Xmin` (0x8F50) and `Xmax` (0x8F59)** via `1A92`/`1B0C`
-(FPS load + store-to-window), and `_VertCmd` writes its X into **`Ymax` (0x8F74) and `Ymin`
-(0x8F6B)** — i.e. they momentarily collapse the *other* axis so the transform produces a
-line spanning the full screen, render with `_PDspGrph`, then `_DeallocFPS1(0x24)` restores
-the real window. [confirmed]
+Note: `_HorizCmd`/`_VertCmd` both `CALL 7933` first, which **allocates a 0x24-byte FPS frame**
+(`LD HL,0x24 / CALL 1537 / SBC HL,DE`) and returns a pointer to it. `_HorizCmd` then **builds the
+line's two endpoints in that frame**: it copies `Xmin` (`0x8F50`) and `Xmax` (`0x8F59`) — the window's
+X range — with `_Mov9B` (`00:1A92`, which reads a window float into the frame), interleaving the
+line's Y (`OP1`) via `_MovFrOP1` (`00:1B0C`), so the endpoints are `(Xmin, y)` and `(Xmax, y)`.
+`_VertCmd` does the same with `Ymin` (`0x8F6B`)/`Ymax` (`0x8F74`) and the line's X. It renders with
+`_PDspGrph`, then `_DeallocFPS1(0x24)` frees the frame — the **live window variables are not
+modified** (the line just spans the current window edges). [confirmed]
 
 ---
 
@@ -175,7 +178,7 @@ the real window. [confirmed]
 **`_PDspGrph`** (`04:7904`, "possibly-display graph") is the gatekeeper between buffer and
 screen. [confirmed]
 - Clears the "need redraw" flag at `(IY+2)`,
-- if the **regraph-pending** bit `(IY+3)&1` is set (`grfDBFlags`/SmartGraph dirty), calls
+- if the **graph-dirty** bit `(IY+3)&1` is set (`graphFlags.graphDraw`, inc `graphFlags=3`/`graphDraw=0`; `1`=redraw needed — this is *not* `grfDBFlags` at `IY+4` nor SmartGraph at `IY+0x17`), calls
   **`_Regraph`** to recompute the whole plot,
 - otherwise checks the split-screen flag (`_Bit_VertSplit`) and copies the buffer to the LCD
   (`graph_redraw_buf` `04:607F`).
@@ -261,9 +264,9 @@ during a regraph or TABLE build.
 - Forward transform `(value−min)/pixelDelta`: structure **[confirmed]** from the
   `37:41F2` disassembly (subtract `228F`, divide `2385`); the exact rounding in `4229` is
   read but the ±sentinel constants are summarized, not exhaustively byte-traced.
-- `_HorizCmd`/`_VertCmd` destination floats: confirmed they `_Mov9B` into the Xmin/Xmax vs
-  Ymax/Ymin pair and `_PDspGrph`; whether they use the live window or a temp copy for the
-  line endpoints would benefit from tracing `HorizVert_setup` (`04:7933`).
+- `_HorizCmd`/`_VertCmd` endpoint build — **resolved**: `7933` allocates a 0x24-byte FPS frame, and
+  the commands `_Mov9B` the window edges (`Xmin`/`Xmax` or `Ymin`/`Ymax`) plus `_MovFrOP1` the line's
+  coordinate (`OP1`) into that frame. The live window variables are not touched.
 - Circle parametric stepping in `3B:7171` (`_DrawCirc2`) not decompiled here (lives on
   page 3B); the `_GrphCirc` setup is confirmed.
 - Y= selection bit (`0x20`; flags byte `0x23` selected / `0x03` deselected) and the style byte

--- a/docs/sub-graphing.md
+++ b/docs/sub-graphing.md
@@ -37,7 +37,7 @@ These are the values the WINDOW editor writes and the grapher reads.
 
 There is a second "u" copy block at `0x8E7E` (`uXmin`…`uXres` at `0x8F3B`) — the
 **uVar** window set used in the alternate (split/table) graph context, and a working/temp
-float pair around `0x8E6A`/`0x8E73` used by the transform code (`UNK_ram_8e6a`). [strong]
+float pair around `0x8E6A`/`0x8E73` used by the transform code. [strong]
 
 `deltaX`/`deltaY` are derived from the window when the graph is set up and feed both the
 forward (real→pixel) and the circle/draw routines. The LCD is **96×64**, but the graph area

--- a/docs/sub-link-transfer.md
+++ b/docs/sub-link-transfer.md
@@ -197,9 +197,9 @@ After the data payload, the sender appends the 16-bit sum and waits for the ACK:
 ```
 On the **receive** side the matching check is `6356`: after streaming the payload it compares the
 accumulated checksum `8678` against the received 16-bit checksum; on mismatch it sends a **0x5A ERR
-packet** (`6385: LD H,0x5A ; CALL 419B`) and raises `_JErrorNo`. The ACK-builder `42FB` echoes the
-peer's saved header (`868B bakHeader`), forces command = **0x56**, length = 0, sends it, then
-`_Mov9B` restores the header.
+packet** (`6385: LD H,0x5A ; CALL 419B`) and raises `_JErrorNo`. The ACK-builder `42FB` saves the
+caller's header to `868B bakHeader`, then builds an ACK with a **fresh local** machine-ID (`CALL 620A`),
+command = **0x56**, length = 0, sends it, and `_Mov9B` restores the saved header.
 
 ---
 
@@ -294,7 +294,7 @@ machinery:
       LD A,0x0B ; (8672)=A          ; sndRecState = request/directory
       LD A,0xC9 ; CALL 6971         ; command setup
       CALL 62B0 (clear link sub-state in 8A0B) ; SET 2,(IY+0x1B)
-      CALL 58ED (→ SET 2,(IY+0x24) ; _ChkFindSym)  ; locate the var
+      CALL 58ED (→ SET 1,(IY+0x24) ; _ChkFindSym)  ; locate the var
       JR 4EAD (shared tail with _LinkXferOP: RES 1,(IY+0x24); 2800; JP 4F3E)
 ```
 Note `4EDD` physically **overlaps / shares the tail** (`4EAD`) with `_LinkXferOP`; they are two
@@ -340,7 +340,7 @@ silent-link engine documented here. **[C for 0x9F path; H for the 0x22-25 mappin
    size) at `867F`, sends it (`41C3`, cmd path), waits for **CTS (0x09)**.
 4. `40DA` streams the **DATA (0x15)** payload via `_PagedGet`→`_SendAByte` (Flash-transparent),
    appends the **16-bit checksum**, waits for **ACK (0x56)**.
-5. `_GetSysInfo` (`00:50DD`)-style metadata and an **EOT (0x92)** close the session.
+5. `_GetSysInfo` (`07:7345`, id `0x50DD`)-style metadata and an **EOT (0x92)** close the session.
 6. Receive direction is the mirror: header in → CTS out → DATA in (buffered 16 bytes →
    RAM/Flash via `6AB1`) → checksum verify (`6356`, NAK 0x5A on error) → ACK out → VAT store (RST5).
 
@@ -362,7 +362,7 @@ silent-link engine documented here. **[C for 0x9F path; H for the 0x22-25 mappin
 | `3C:4199` | `lnk_send_cts` | send CTS (cmd 0x09) |
 | `3C:4338` | `lnk_recv_header` | receive + validate 4-byte header |
 | `3C:620A` | `lnk_local_machine_id` | pick local machine-ID from IY+0x1B mode |
-| `3C:42FB` | `lnk_send_ack` | build+send ACK (cmd 0x56) from saved header |
+| `3C:42FB` | `lnk_send_ack` | build+send ACK (cmd 0x56, fresh local machine-ID), restoring the saved header |
 | `3C:4292` | `lnk_recv_data` | receive DATA payload, 16-byte Flash batching, checksum |
 | `3C:6356` | `lnk_verify_cksum` | verify count vs len; NAK 0x5A on mismatch |
 | `3C:6AB1` | `lnk_flush_block` | flush 16-byte staging block to RAM/Flash (port 0x14) |
@@ -376,7 +376,7 @@ silent-link engine documented here. **[C for 0x9F path; H for the 0x22-25 mappin
 | `3C:6994` | `lnk_recv_store` | receive var + VAT store sequence (expects 0x09 then 0x15) |
 | `00:278D` | `_ErrLinkXmit` | `_JError(0x9F)` E_LnkErr |
 | `00:2799` | `_JErrorNo` | raise current pending error (link → 0x9F) |
-| `00:50DD` | `_GetSysInfo` | system info reply (used in link sessions) |
+| `07:7345` | `_GetSysInfo` (id `0x50DD`) | system info reply (used in link sessions) |
 | `00:4A14` | `_SendVarCmd` (bcall id) | → 3C:4EDD |
 
 **Ports:** `0x00` = bit-bang link (tip/ring); `0x08`-`0x0D` = HW link-assist control/status/data

--- a/docs/sub-matrix-list.md
+++ b/docs/sub-matrix-list.md
@@ -135,7 +135,7 @@ Matrix element wrappers: [C]
 ### Internal index helpers reused by the algorithms [C]
 - **`mele_adr_af_jp` (`02:403C`)** = `_AdrMEle(currentIJ) ; RST4` — "load `[M](i,j)` to OP1" (the elimination
   inner-loop read). Indices come from the loop state at `84AF/84B3/84B4`.
-- **`mele_adr_to8483` (`02:4051`)** = `_AdrMEle ; _Mov9B(→OP3@8483)` — load element to OP3.
+- **`mele_adr_to8483` (`02:4051`)** = `_AdrMEle ; _Mov9B(→OP2@8483)` — load element to OP2.
 - **`mele_put_af` (`02:405A`) / `mele_put_d3` (`02:405E`)** = `_AdrMEle ; _CkValidNum ; _MovFrOP1` — store OP1 back to `[M](i,j)`.
 - **`_ListIdxTimes9` (`35:79E9`)** = `_HLTimes9(idx)` then a small dispatch (`RST4`) — the list
   analogue used in a few list-builder paths.
@@ -149,7 +149,7 @@ Matrix element wrappers: [C]
 |---|---|---|
 | `_CreateRList` | `00:10C4` | new real list: `count*9+2` bytes (§1) [C] |
 | `_CreateCList` | `00:1109` | new complex list: `count*18+2` [C] |
-| `_InsertList` / `_IncLstSize` | `07:4F07` (body `07:4EF4`) | grow a list in place via `_InsertMem`; caps length at 999 (`0x3E7`), else `E_Dimension 0x8C` (`07:4F00 JP Z,0x2719 → LD A,0x8C`) [C] |
+| `_IncLstSize` | `07:4EF4` | grow a list in place via `_InsertMem`; caps length at 999 (`0x3E7`), else `E_Dimension 0x8C` (`07:4F00 JP Z,0x2719 → LD A,0x8C`). `_InsertList` is the distinct sibling at `07:4F07`. [C] |
 | `_DelListEl` | `07:4F43` | delete element(s): `_HLTimes9(index)` to size the gap (×2 if complex, `& 0x1F == 0x0D`), then `_DelMem` via a cross-page jump [C] |
 | `_RedimMat`/`_ConvDim` | `07:4D3B` / `38:741F` | re-dimension (shared with matrices); `_ConvDim`/`_ConvDim00` (`38:741F/7422`) coerce OP1 to a real index first [C] |
 
@@ -454,8 +454,8 @@ fact that it is a separate driver, not `42A6`, is confirmed** by the two-caller 
   Flash cannot be written in place).
 - **Scratch RAM used by the algorithms** (verified operands): `84AF` (current dims / i,j loop
   state), `84B0/84B3/84B4` (pivot, k, row counters), `84B7` (dims copy), `84D3/84D5/84D7`
-  (data pointers + the permutation vector base), `8478`=OP1, `8483`=OP3, `8499`=OP6/type,
-  `84AF`-region = the matrix-op loop frame.
+  (data pointers + the permutation vector base), `8478`=OP1, `8483`=OP2, `8499`=OP4,
+  `84AF`=OP6 region = the matrix-op loop frame.
 
 ---
 

--- a/docs/sub-solver-numeric.md
+++ b/docs/sub-solver-numeric.md
@@ -58,7 +58,8 @@ At the heart is a callback that, given the trial value in `OP1`, returns `f(x) =
 of the equation. Located around `39:468F`:
 
 1. `_CkValidNum` (`ram:1E9B`), then `_MovFrOP1` (`ram:1B0C`) stores the current guess into
-   the **solve variable** (named system var addressed via `(065B)`).
+   the **solve variable** (its data pointer is loaded from `(9306)`, in the expression-stack
+   region — the bytes are `ED 5B 06 93` = `LD DE,(9306)`).
 2. It installs an **error trap** (`39:46D9 CALL 327F`; `RES/SET 2,(IY+7)`) and re-parses /
    re-evaluates the stored equation formula (page-0x39 hosts a parse/token walker at
    `39:327F` using `parse_advance 7248` / `parse_cur_tok 72DA`-style cursors, mirroring the
@@ -153,7 +154,7 @@ The five-variable **time-value-of-money** solver (`N`, `I%`, `PV`, `PMT`, `FV`, 
 `P/Y`, `C/Y`, and the PMT:END/BEGIN flag) lives on flash page **0x3A**. Each variable is a
 named system FP var; the routine loads them via small accessors:
 
-- `3A:7F02` loads the var named at `(D35B)`, `3A:7F0F` the one at `(D55B)`, etc.
+- `3A:7F02` loads the pointer at `(84D3)` (`iMathPtr1`; `ED 5B D3 84` = `LD DE,(84D3)`), `3A:7F0F` the one at `(84D5)` (`iMathPtr2`), etc.
   (`(D?5B)` are the finance sysvar VAT slots). `(84D3)`=`iMathPtr1`, `(84D9)`=`iMathPtr4`,
   `(84AF)`=OP6, `(84D3)`/`(84D9)`/`(84D3)` hold the iteration state. **[confirmed]**
 
@@ -226,7 +227,7 @@ Ghidra function `fnint_body` at `33:4D00` (extent `33:4D00…4E91`):
 
 - builds interval midpoints and half-widths: `_FPSub` (`2297`), `_TimesPt5` (`2382`, ×0.5),
   `_FPDiv` (`2541`). The bytes at `33:4D18` are **executable code** — `33:4D18 21 83 84`
-  (`LD HL,0x8483`), `33:4D1B 3E 60` (`LD A,0x60`), `33:4D1D CD 65 1B` (`CALL _OP2SetA`/`1B65`) — loading the
+  (`LD HL,0x8483`), `33:4D1B 3E 60` (`LD A,0x60`), `33:4D1D CD 65 1B` (`CALL fp_set_digit` `1B65`; not `_OP2SetA`, whose body is `1B24`) — loading the
   scalar **0x60 = 96**
   (a working digit/scale count), not a quadrature weight. **[confirmed bytes]**
 - maintains a working set of partial sums in an **FPS frame** (`_AllocFPS 1534`,
@@ -321,7 +322,7 @@ Equation Solver / `solve(` (page 0x39):
 TVM / finance solver (page 0x3A):
 ```
 3A:70A2  tvm_solve_iterate          (Newton on I%, 64-iter FPS-framed loop)
-3A:7F02  tvm_load_var_D35B          3A:7F0F  tvm_load_var_D55B   (finance var accessors)
+3A:7F02  tvm_load_var (iMathPtr1)   3A:7F0F  tvm_load_var (iMathPtr2)   (finance var accessors)
 3A:7206  ->ITERATIONS(0x99)
 ```
 
@@ -375,7 +376,7 @@ The four open questions from the prior pass are now resolved against the bytes:
   weight table**; its sole FP constant is `ln(10)·100` at `33:4E92`, used (with bcall `_LnX`)
   to convert digit-tolerance to a decimal error bound. With explicit ×0.5 interval bisection
   and a coarse-vs-fine estimate comparison, it is an **adaptive Newton–Cotes / Simpson-class
-  bisection** integrator. `33:4D1B` is executable code (`LD A,0x60; _OP2SetA`).
+  bisection** integrator. `33:4D1B` is executable code (`LD A,0x60; CALL fp_set_digit`).
 - **TVM `_SinH` (id 0x40CF) — resolved (§2.3).** The TVM rate loop calls `_SinH` at
   `3A:710B` (`0x40C6/0x40CF/0x40ED` are three distinct hyperbolic bcalls); it evaluates the
   annuity / compound factor in hyperbolic form for numerical stability at small rates.

--- a/docs/sub-statistics.md
+++ b/docs/sub-statistics.md
@@ -58,7 +58,7 @@ system variables a student recalls by name (`[2nd][STAT] ▸ VARS`):
 | `8B00` | `QuadC`   | `c`   | regression coeff c |
 | `8B09` | `CubeD`   | `d`   | regression coeff d |
 | `8B12` | `QuartE`  | `e`   | regression coeff e |
-| `8B1B`…`8B4E` | `MedX1/2/3`, `MedY1/2/3` | | Med‑Med (×3 partitions) |
+| `8B1B`…`8B50` | `MedX1/2/3`, `MedY1/2/3` (`8B1B/8B24/8B2D/8B36/8B3F/8B48`) | | Med‑Med (×3 partitions) |
 
 Continuing past the table (also `.inc`): `PStat`/`ZStat`/`TStat`/`ChiStat`/
 `FStat`/`DF`/`Phat…`/`MeanX1`/`StdX1`/`StatN1`/`MeanX2`/`StdX2`/`StatN2`/`StdXP2`/
@@ -67,7 +67,7 @@ menu) and are written by the test commands, not by 1/2‑Var Stats. An ANOVA blo
 `anovaf_vars` (`F_DF/F_SS/F_MS/E_DF/E_SS/E_MS`) follows.
 
 **STAT‑TESTS are separate command handlers [confirmed scope].** `Z‑Test`/`T‑Test`/`χ²‑Test`/
-`2‑SampFTest`/`ANOVA(` etc. come in as their own 2‑byte (`E1`‑prefixed) command tokens — e.g.
+`2‑SampFTest`/`ANOVA(` etc. come in as their own 2‑byte `t2ByteTok` (`0xBB`)‑prefixed command tokens — e.g.
 `LinRegTTest=34h` noted in §3 — and are **not** dispatched through `_OneVar` (whose token map is
 only `F2`–`FF`, §3). They fill the `PStat…SStat`/`anovaf_vars` block above directly. No
 `PStat`/`ZStat`‑writing routine appears among the page‑0x3A `stat_*` symbols (all of which are
@@ -156,8 +156,8 @@ as a model index. From `ti83plus.inc`:
 | `tLR1`    | `FF` | `LinReg(ax+b)` | degree‑1 (ax+b form) |
 
 `CubicReg`/`QuartReg` come in as the regression tokens `tCubicR=2Eh`/`tQuartR=2Fh`;
-`SinReg=32h`, `Logistic=33h`, `LinRegTTest=34h` are the extended (`E1`‑prefixed)
-tokens. Degree for the polynomial solver = the model index; the coefficient
+`SinReg=32h`, `Logistic=33h`, `LinRegTTest=34h` are 2‑byte `t2ByteTok` (`0xBB`)‑prefixed
+tokens (their `2Eh`/`2Fh`/`32h`/`33h`/`34h` values are the *second* byte after `0xBB`). Degree for the polynomial solver = the model index; the coefficient
 fan‑out into `QuadA..QuartE` is naturally sized by degree. [confirmed/standard]
 
 `SortA(`/`SortD(` are **separate** tokens (`tSortA=E3h`, `tSortD=E4h`) with their
@@ -212,9 +212,10 @@ power‑sums `Σxⁱ` (i = 0 … 2d) and the right‑hand side `Σxⁱy`, stored
 **Non‑polynomial regressions transform first** [confirmed]: the front‑end at
 `658a`+ checks the command code and, for `ExpReg`/`PwrReg` (`ln y`),
 `LnReg`/`PwrReg` (`ln x`), pre‑applies the logarithm to each element before
-accumulating, then exponentiates the resulting linear coefficients (the
-`760f/75e4/79b9` and `7002/7013` branches call into the page‑02 `_LnX`/`_EToX`
-transcendentals — see `sub-calculation.md §5`). This is the standard
+accumulating, then exponentiates the resulting linear coefficients off page 0x3A. The
+per‑element `ln` is in the element fetch `stat_next_elem` (`3A:6F6A`): `LD A,(8A36); CP 4;
+RET NC` then `bcall _LnX` at `3A:6F72` for model codes `< 4` (`ExpReg`/`LnReg`/`PwrReg`); the
+back‑transform `_EToX`/`_TenX` lives on page 0x02 (see `sub-calculation.md §5`). This is the standard
 "linearize, fit a line, transform back" method; `r` is the correlation of the
 **transformed** data.
 
@@ -257,7 +258,9 @@ matrix `[ M | Σxⁱy ]`. `_OneVar` solves it **in place by Gauss‑Jordan elimi
 6845: CALL 3939 (_SqRoot) ; 6849 ; CALL 2541 (_FPDiv)  ; (forms r²/r from the fit)
 684f: LD A,12 ; CALL 213d           ; r-related store/guard
 6859..6876: row-reduce all other rows (3aa7 get, 238b _FPMult, RST 30 _FPAdd)
-6880: CALL 2541 ; on a zero pivot → LD A,35/36 ; CALL 213d  (SINGULAR MAT)
+6880: CALL 2541 (_FPDiv) ; CP 2 ; LD A,0x35/0x36 ; CALL 213d  ; *** _Sto_StatVar stores into the
+                                                              ; statVar slots id 0x35/0x36 — NOT a SingularMat raise.
+                                                              ; the zero-pivot guard is the 67F7→212D path → 0x83.
 68d6..6953: back-substitution — each coeff = (rhs − Σ known·M) / pivot
    (3aa7/3aa1 matrix access, 238b _FPMult, RST 30/RST 8 accumulate,
     24bd _InvOP1S to subtract, 2541 _FPDiv)
@@ -348,7 +351,7 @@ list data (sets `Xmin/Xmax/Ymin/Ymax` from `minX/maxX/minY/maxY`). See
 ## 9. Distributions (DISTR menu) — *not* part of STAT‑CALC [confirmed scope]
 
 `normalpdf(`, `normalcdf(`, `invNorm(`, `binompdf(`, `tcdf(`, `χ²cdf(`, `Fcdf(`,
-etc. are **parser functions** (DISTR‑menu tokens, the `E1`/`E2`‑prefixed
+etc. are **parser functions** (DISTR‑menu tokens, the `t2ByteTok` (`0xBB`)‑prefixed
 two‑byte tokens like `tShadeNorm=35h`), evaluated through the normal function
 dispatch of the TI‑BASIC parser, **not** through `_OneVar`. They are not
 exposed as named bcalls in this OS image (a search of `bcall_targets.txt` finds
@@ -368,7 +371,7 @@ cores returns **no** `normalcdf`/`erf`/incomplete‑gamma/incomplete‑beta entr
 symbol on page 0x3A is part of the `_OneVar` STAT‑CALC engine (accumulate / variance / median /
 sort / regression), not a DISTR core. So the erf / incomplete‑gamma / incomplete‑beta continued
 fractions are **[I] — outside the STAT‑CALC engine**, sitting behind the parser's 2‑byte
-(`E1`/`E2`‑prefixed) DISTR‑token function table; their exact page/address is not exposed as a
+(`0xBB`‑prefixed) DISTR‑token function table; their exact page/address is not exposed as a
 named routine in this DB. [confirmed scope; address [I]]
 
 ---

--- a/docs/sub-table-yvars.md
+++ b/docs/sub-table-yvars.md
@@ -225,11 +225,13 @@ running-X slot:
 ```
 
 i.e. the first row's independent value is **TblStart**. A working float at
-`0x8622`/`0x862B` holds the current row's X. The "advance to next row" step
-(`05:65DC`) adds **TblStep** to it:
+`0x8622`/`0x862B` holds the current row's X. The row index is bounds-checked at
+`05:65DC` (`LD A,(0x91E0); LD HL,0x91DC; CP (HL); RET` — current row vs the last
+row), and the per-row X is computed as `TblStart + k·TblStep` rather than by an
+incremental add:
 
 ```z80
-05:65DC  … LD HL,(table indices) … CALL 0x6D67 (advance) …
+05:65DC  LD A,(0x91E0) ; LD HL,0x91DC ; CP (HL) ; RET   ; row-index bound check
 05:6359  LD A,(0x91DD) … LD DE,0x9221 / 0x91E2 (cell buffers)
          LD HL,(0x91DC /* row idx */) ; ADD ; CALL _LdHLind ; ADD HL,DE
 ```
@@ -306,7 +308,7 @@ columns, drawn with the large font through the home-screen text primitives
            LD DE,(0x9192 YOutDat) ; the Y-column value pointer
            CP 2 / CP 5            ; column-kind dispatch (X col vs Y col vs input)
            CALL 0x7E7C ; CALL 0x7E98   ; render the cached value into the cell
-           CALL 0x65DC            ; advance running-X (= +TblStep) for next row
+           CALL 0x65DC            ; row-index bound check (current row vs last)
            INC row ; … ; LD (0x91DC),A
 ```
 
@@ -335,7 +337,7 @@ next TABLE view to recompute:
 | `02:7B35` bytes | editing **TblStart/ΔTbl/Indpnt/Depend** in TBLSET |
 | `37:5F3D` | toggling Indpnt or Depend on the setup screen |
 | `38:6340`, `38:4809`, `38:54CD` | the **parser** storing into a Y= equation or a relevant var (editing `Y1=…`, `→Y1`, or changing `X`/window) |
-| `00:4105` | boot / reset (`RAM clear`) initialises the table as dirty |
+| boot / reset (`RAM clear`) | initialises the table as dirty (`reTable` set); the exact init site is not pinned here (`00:4105` is the "Resetting All…" message string, not the setter) |
 
 Conversely only the recompute driver **clears** it (`05:5DD7`, `05:62FD`,
 `05:64DE` → `RES 6,(IY+0x13)`). [confirmed]
@@ -359,7 +361,7 @@ Conversely only the recompute driver **clears** it (`05:5DD7`, `05:62FD`,
    - per row: `_StoX` the running-X, evaluate `Y1`'s tokens via the page-38
      evaluator (`_Find_Parse_Formula` / `_ParseInp`) → OP1 = `X²+1`, format and
      stash into the cell cache (`0x91E2`/`0x9221`),
-   - advance running-X by `TblStep` (`05:65DC`) and repeat,
+   - advance to the next row (bound-checked at `05:65DC`; X = `TblStart + k·TblStep`) and repeat,
    - clear `reTable`.
 4. The grid paints (`05:7E45`) the cached `X` and `Y1` columns as large-font text;
    scrolling (`05:6014`) slides the cache and computes only newly exposed rows.
@@ -386,7 +388,7 @@ page_05:5d0d  table_editor_main                ; reTable? recompute : use cache;
 page_05:5dd7  table_recompute                  ; seed X, fill cache, clear reTable
 page_05:774b  table_seed_runX_from_TblMin      ; runningX(0x862B) ← TblMin
 page_05:773f  table_seed_runX_from_TblMin2     ; same, split-graph path
-page_05:65dc  table_next_X                     ; runningX += TblStep
+page_05:65dc  table_row_bound                   ; row-index bound check (91E0 vs (91DC))
 page_05:5ee1  table_fill_cache_loop            ; per-row value-cache fill (0x91E2)
 page_05:6014  table_scroll_cache               ; slide cell cache on scroll (LDIR/LDDR)
 page_05:6d40  table_mode_test                  ; BIT autoFill/autoCalc (Auto vs Ask)
@@ -419,7 +421,7 @@ page_33:5023  _GraphParseTok                   ; pre-scan equation tokens (graph
 
 ; --- reTable (dirty) setters ---
 page_38:6340 / 38:4809 / 38:54cd  parser sets reTable on Y=/var edit
-page_00:4105  boot sets reTable
+(boot/RAM-clear)  sets reTable (init site not pinned; 00:4105 is a message string)
 ```
 
 ---

--- a/docs/sub-tibasic.md
+++ b/docs/sub-tibasic.md
@@ -118,7 +118,7 @@ is done by `chk_tok_end` (`38:72E0`) / `parse_cur_err_illegal` (`38:70F8`).
 - `_StoAns` (`38:6251`) stores OP1 into `Ans` (`_CkOP1Real` path; the bytes that
   follow are the Ans-var token table). `_RclAns` (`38:679F`) = `_AnsName` then
   `_RclVarSym`.
-- `_AnsName` (`38:74B7`): `_ZeroOP1; OP1.exp = 0x72` — builds the OP1 name for
+- `_AnsName` (`38:74B7`): `_ZeroOP1; (OP1+1)=0x72` (the name's type/class byte at `0x8479`, not an exponent — OP1 holds a name here) — builds the OP1 name for
   the `Ans` variable (token class `0x72`).
 - `_StoSysTok`/`_RclSysTok` (`38:623B`/`683E`) store/recall a system token
   variable (Xmin etc.) into/from OP1.
@@ -312,8 +312,9 @@ runs and off at `Done`. **[confirmed]**
 2. `chk_tok_end` (`38:72E0`) classifies it into a small class number (`<=3` operand/expr,
    `4` = syntax error, others = operator/command). Flagged tokens reclassify via
    `set_split_rows` (`ram:20A0`) when `IY+9 & 0x80`.
-3. `parse_cur_err_illegal` (`38:70F8`) maps the token byte to a grammar/precedence class (tokens
-   `>0xF1` get `+0x12`, folding the high token page into the class space).
+3. `parse_cur_err_illegal` (`38:70F8`) validates the current token; its caller (at `38:6FBE`) then
+   maps the token byte to a grammar/precedence class — tokens `≥0xF2` get `+0x12` (`38:6FBE: ADD A,0x12`),
+   folding the high token page into the class space.
 4. The precedence level (`cVar4` = 1/2/3) selects the production handler base:
    `0x4000` (base term — the **flat handler-pointer table**, indexed by token class),
    `0x478C` (postfix `^`/`!`), or `0x7175` (leaf) — `0x478C` and `0x7175` are raw code
@@ -345,7 +346,7 @@ page_38:6f63   if_isg_stmt_handler        ; per-statement If/IS>( dispatch
 page_38:4130   blockmatch_end_else        ; nest-counting End/Else scanner
 page_38:4180   parse_scan_tokens          ; skip-to-delimiter (2-byte aware)
 page_38:4870   goto_lbl_name_scanner      ; scan label name, jump to search
-page_38:7600   store_target_name_scanner  ; →VAR store-target name scanner (live DB name)
+page_38:7600   store_target_name_scanner  ; →VAR store-target name scanner (inferred; live DB auto-name is set_tblgraph_draw_xpage)
 page_38:72da   parse_cur_tok
 page_38:7248   parse_advance
 page_38:5cd8   parse_expect_or_err

--- a/docs/sub-usb-asic.md
+++ b/docs/sub-usb-asic.md
@@ -225,7 +225,7 @@ mask to physical page `0x35`.
 |----------|-------------|------|-----------------------|
 | `50F2` | `_SendUSBData` | `35:4DD3` | Sends from `HL` with byte count in `DE`; stores progress at `0x9C7E`/`0x9C81` and writes 64-byte chunks to port `0xA2`. |
 | `50F5` | `_AppGetCBLUSB` | `3B:54C7` | Sets `IY+0x1B` bit 1, clears bit 2, then reaches `_GetVarCmdUSB`. |
-| `50F8` | `_AppGetCalcUSB` | `3B:54F0` | Clears `IY+0x1B` bit 0 before the shared get-var path. |
+| `50F8` | `_AppGetCalcUSB` | `3B:54F0` | At `3B:54DE` clears `IY+0x16` bit 0 and sets `sndRecState`=0x15, then `bcall 0x50FB` (shared get-var path). |
 | `50FB` | `_GetVarCmdUSB` / `_LinkXferOP` | `3C:4DD2` | USB-first variable command wrapper described above. |
 | `5254` | `_InitUSBDeviceCallback` | `35:4696` | Initializes device mode, stores callback page/address at `0x9C13`/`0x9C14`, and returns `0xFC`-`0xFF` style error bytes with carry set on failure. |
 | `5257` / `5311` | `_KillUSBDevice` / `_RecycleUSB` | `35:46FC` / `35:5B9B` | Clears callback state and recycles through the same cleanup path. |
@@ -235,7 +235,7 @@ mask to physical page `0x35`.
 | `5290` | `_InitUSBDevice` | `35:42B0` | Main controller/device initialization path; uses `0x4C`/`0x4D` line handshakes and endpoint ports `0x80`-`0x9B`. |
 | `5293` | `_KillUSBPeripheral` | `35:59CF` | Peripheral teardown; sets controller state `0x9C28 = 5` and manipulates ports `0x54`/`0x81`. |
 | `530B` | `_ToggleUSBSmartPadInput` | `35:5B84` | Sets or clears bit 3 in `0x9C75` according to `A == 1`. |
-| `530E` | `_IsUSBDeviceConnected` | `35:5B92` | Preserves `A`; returns flags from `IN (0x81) & 0x40`, matching the `.inc` comment. |
+| `530E` | `_IsUSBDeviceConnected` | `35:5B92` | Preserves `A`; returns flags from `IN (0x81) & 0x40` (bit 6). (The `.inc` comment guesses `bit 4,(81h)`, but the body actually masks bit 6.) |
 
 ## How to use it in code [grounded by OS calls]
 

--- a/docs/sub-vat-archive.md
+++ b/docs/sub-vat-archive.md
@@ -84,12 +84,12 @@ For an **archived** entry the data address (`addrLSB/MSB`) points into the Flash
 - Set OP1 type = 0xFF placeholder (`62A9: LD A,FF / LD (8478),A`), parse the destination name.
 - `5F45` resolves/creates the target symbol; then it copies the value. It dispatches on the
   destination name token (`849B`): list-element store (`0x2A` → bounds-checks via `_ErrDimension`),
-  matrix element, etc. Ultimately a `_CreateXxx` carves RAM with `_InsertMem` and the data is copied.
+  matrix element, etc. Ultimately a `_Create*` routine carves RAM with `_InsertMem` and the data is copied.
 - A store **into an archived var is not done in place**; the OS unarchives first (you cannot rewrite
   Flash in place) — see the `_Arc_Unarc` direction logic in §4. [I/H]
 
 **Recall** `_RclVarSym` (`38:67B1`) and `_RclVarPush` (`3A:5D07`):
-- `_RclVarSym` calls `RST 2` (`17A6`/`_FindSym`), then checks the name token (`8479`). For a list
+- `_RclVarSym` calls `RST 10h` (`17A6`, a `_FindSym`+error-check wrapper: `RST 10h; JP C,271D`), then checks the name token (`8479`). For a list
   recall (`63`/`2A`) it sizes the data with `_DataSize` (`00:1485`) and copies it into a work buffer
   (`91E0`), using `_LdHLind` and cross-page helpers; ends `JP _OP4ToOP1`.
 - `_DataSize` (`00:1485`): returns the variable's data byte-count in DE from the type byte — real=9,
@@ -114,31 +114,35 @@ _Arc_Unarc (07:6248):
   CALL _ChkFindSym (0E60)      ; locate the VAT entry; C ⇒ JP 271D (undefined)
   DI
   LD (981C),HL                 ; chkDelPtr3 = entry ptr
-  LD A,B ; OR A ; JR Z,..      ; B = page byte: 0 ⇒ currently in RAM, else ⇒ in Flash
-      (RAM) LD A,(HL); CP 0x17 ; Group? ⇒ JP 26E0 reject  [groups archive via a different path]
-            ...  CALL 61F4     ; *** RAM → Flash:  archive ***
-      (Flash) CALL 6107        ; *** Flash → RAM:  unarchive ***
+  LD A,B ; OR A ; JR Z,6272    ; B = page byte: 0 ⇒ currently in RAM, else ⇒ in Flash
+      (Flash, B≠0) LD A,(HL); CP 0x17 ; Group? ⇒ JP 26E0 reject  [groups archive via a different path]
+                   CALL 61F4   ; *** Flash → RAM:  unarchive ***
+   6272 (RAM, B==0):  CALL 6107        ; *** RAM → Flash:  archive ***
   ... type-0x5D (complex-list) special-case via 32A9 / cross_page 37:4288
   LD A,(83EE); OR A; EI; RET
 ```
 
-`628B` is the **archivable-name validator**: after `_CkOP1Real`, it accepts the system/real name
-tokens `0x58 0x59 0x54 0x5B 0x52 0x72 0xFC`, complex `0x0C`, list `0x01`/`0x0D`, etc.; rejects others
-via the `26E0` shim (`LD A,0xB2` = E_Variable, ERR:VARIABLE → `_JError`). (`_arc_59f1` @`07:59F1` and `_arc_5936` @`07:5936` are companion name/range
+`628B` is the **archivable-name guard**: after `_CkOP1Real` it returns **Z for the non-archivable
+single-letter real/sysvar name tokens** `0x58 0x59 0x54 0x5B 0x52 0x72 0xFC` (`CP n; RET Z` chain), so
+`_Arc_Unarc`'s `JP Z,26E0` rejects them via the `26E0` shim (`LD A,0xB2` = E_Variable, ERR:VARIABLE →
+`_JError`); archivable classes (lists, matrices, programs, appvars, …) return NZ and continue. (`_arc_59f1` @`07:59F1` and `_arc_5936` @`07:5936` are companion name/range
 validators for the catalog archive command.)
 
-### 4a. RAM → Flash (archive), `61F4` [C]
+Direction note: the `B`-page test sends an **in-RAM** var (`B==0`) to `6107` (archive) and an
+**in-Flash** var (`B≠0`) to `61F4` (unarchive). `6107` is the one that programs Flash and frees the
+RAM copy; `61F4` is the one that carves RAM and copies the data back out of Flash.
+
+### 4a. RAM → Flash (archive), `6107` [C]
 ```z80
-61F4:  LD (83EF),DE ; LD (83EE),A      ; arcInfo.dataPtr/page = source (RAM)
-       CALL 6335                       ; 6331/6335: stash vatPtr (83F1), compute dataSize (83F5) via _DataSize
-       CALL 32D3                       ; size accounting
-       LD A,(HL) ; CALL 146C           ; add header overhead → 83F9 (sizeFull)
-       EX DE,HL ; CALL _EnoughMem(0FA6); make sure the freed RAM bookkeeping is OK
-                JP C,_ErrMemory(2721)
-       OR 1 ; CALL FUN_ram_0f0c        ; mark VAT type byte: set the archive flag bit
-       LD (83F3),DE
-       CALL 3003 (cross_page 3D:64AA)  ; *** do the actual Flash program ***  (see §6)
+6107:  CALL 7866 ; DI
+       CALL 614B                       ; size/accounting: (83F1)=vatPtr, _DataSize→83F7;
+                                       ;   616C reserves the archive-Flash slot
+       CALL 2FF1 (cross_page 3D:64AA)  ; *** program the data into the archive Flash ***  (see §6)
+       LD HL,(83F3) ; LD DE,(83F7) ; CALL _DelMem (1368)  ; release the old RAM copy
        RET
+616C:  reads vatPtr type, AND 0x1F (clean type for the record header),
+       LD HL,(83F7)+(83F5) ; ADC ; JP C,2729 (E_Invalid/E_IllegalNest/E_Bound 0x8F/0x90/0x91)  ; size overflow?
+       reserves a Flash slot via 2FDF(3D:61AF) / 2FF7(3D:62C2)
 ```
 The data is **appended** to the archive Flash (Flash cannot be overwritten in place). The VAT entry's
 type byte gets its archive flag set and its data ptr/page rewritten to point into Flash; the old RAM
@@ -147,22 +151,26 @@ fresh archived record plus a copy of the symbol header/name and data (status mar
 `0xFE`=in-progress / `0xFC`=valid / `0xF0`=deleted, with `0xFF`=erased/empty; the bit-clearing
 mechanism is confirmed in §6a). `3D:64AA` is not a defined function in the current live DB; the
 `flash_write_record` name for it is a project-local inferred label, not a WikiTI or `ti83plus.inc`
-equate.
+equate. `_Chk_Batt_Low` (`00:0D07`) gates the Flash write — archiving aborts on low battery
+(`61C5: CALL _Chk_Batt_Low`).
 
-### 4b. Flash → RAM (unarchive), `6107` [C]
+### 4b. Flash → RAM (unarchive), `61F4` [C]
 ```z80
-6107:  CALL 7866 ; DI
-       CALL 614B   ; compute sizes:  (83F1)=vatPtr, _DataSize→83F7, free-RAM check via 616C
-       CALL 2FF1 (cross_page 3D:61AF)  ; copy the data Flash→RAM (program the heap)
-       LD HL,(83F3) ; LD DE,(83F7) ; CALL _DelMem (1368)  ; close the old flash slot bookkeeping
+61F4:  LD (83EF),DE ; LD (83EE),A      ; arcInfo.dataPtr/page = source (Flash page+addr from FindSym)
+       CALL 6335                       ; 6331/6335: stash vatPtr (83F1), compute dataSize (83F5) via _DataSize
+       CALL 32D3                       ; size accounting
+       LD A,(HL) ; CALL 146C           ; add header overhead → 83F9 (sizeFull)
+       EX DE,HL ; CALL _EnoughMem(0FA6); ensure there is RAM room for the unarchived copy
+                JP C,_ErrMemory(2721)
+       OR 1 ; CALL 0F0C                ; carve the RAM gap (internal create-gap routine)
+       LD (83F3),DE                    ; destPtr = new RAM address
+       CALL 3003 (cross_page 3D:6440)  ; *** page-3D unarchive worker: copy Flash→RAM, retire the old record ***
        RET
-616C:  ... reads vatPtr type, AND 0x1F (strip archive flag),
-       LD HL,(83F7)+(83F5) ; ADC ; JP C,2729 (E_Invalid/E_IllegalNest/E_Bound 0x8F/0x90/0x91)  ; fits in RAM?
-       allocate via 2FDF(3D:61AF) / 2FF7(3D:62C2)
 ```
-On unarchive the entry's **archive flag is cleared** and the data ptr/page is rewritten back to the
-new RAM address; the Flash copy is left marked dead (reclaimed at the next GC). `_Chk_Batt_Low`
-(`00:0D07`) gates the Flash write — archiving aborts on low battery (`61C5: CALL _Chk_Batt_Low`).
+The data is copied from Flash into the freshly-carved RAM gap. The VAT entry's **archive flag is
+cleared** and its data ptr/page rewritten back to the new RAM address; the old Flash record is left
+marked dead (`0xF0`, reclaimed at the next GC). `3D:6440` shares the page-3D flash-control prologue
+(`OUT (0x14)`) and is not a defined function in the current live DB.
 
 ### 4c. Errors raised on the path [C]
 - `2785: LD A,0x31` → `_JError` = **E_ArchFull (0x31)** "ERR:ARCHIVE FULL" (no room even after GC).
@@ -304,7 +312,7 @@ the classic TI-83+/84+ behaviour, now pinned to addresses.
 - **`_EnoughMem` (`00:0FA6`)** — ensure N free bytes; if short it walks the temp/scratch entries from
   `pTemp(982E)` down toward `OPBase(9826)` at a **9-byte stride**, and `_DelVar`s any entry whose flag
   byte has bit 7 (`& 0x80`) set (a reclaimable temporary), looping until enough or exhausted. Used by
-  `_CreateXxx` and by the unarchive RAM-fit check (`61F4` calls it before allocating).
+  the `_Create*` routines and by the unarchive RAM-fit check (`61F4` calls it before allocating).
 - **`_InsertMem` (`00:0F81`)** / **`_DelMem` (`00:1368`)** — open / close a gap at HL by block-moving
   everything above; `_InsertMem` fails `E_Memory` if it would collide with the VAT.
 - **Free archive (Flash)** is computed inside the Flash layer. The free-space sum is at `3D:6413`
@@ -319,8 +327,8 @@ the classic TI-83+/84+ behaviour, now pinned to addresses.
 |------------|------|------|
 | `07:6248` | `_Arc_Unarc` | archive/unarchive entry; toggles arc flag, dispatches RAM↔Flash |
 | `07:628B` | `arc_chk_name` | archivable-name validator |
-| `07:61F4` | `arc_ram_to_flash` | RAM→Flash archive worker |
-| `07:6107` | `arc_flash_to_ram` | Flash→RAM unarchive worker |
+| `07:6107` | `arc_ram_to_flash` | RAM→Flash archive worker (programs Flash, frees old RAM) |
+| `07:61F4` | `arc_flash_to_ram` | Flash→RAM unarchive worker (carves RAM, copies from Flash) |
 | `07:6331` | `arc_size_setup` | stash vatPtr, compute dataSize into arcInfo |
 | `07:61DC` | `arc_save_info` | save 12-byte arcInfo into savedArcInfo; `07:61E8` (restore candidate) is not a defined function in the live DB |
 | `07:565F` | `findsym_scan` | the real `_FindSym` VAT scanner |

--- a/docs/sub-vat-archive.md
+++ b/docs/sub-vat-archive.md
@@ -388,9 +388,10 @@ Ports: **0x06** = bank-A page select (Flash window), **0x14** = Flash write/eras
   body-undisassembled until the lower-level page-3C/3D helper graph is split cleanly.
 - **Group archive path — partially pinned [H/I].** `_DataSize` (`00:1485`) confirms a Group
   (type `0x17`, like AppVar `0x15`/`0x16`) carries a leading word-size header, so a group *can* be
-  stored as one Flash blob. The single-call RAM→Flash worker `61F4` is reached only after
-  `_Arc_Unarc` rejects `0x17` (the `CP 0x17` → `26E0` reject), so groups must be archived through a
-  separate routine that walks the group's member list. That member-walk routine is **not
+  stored as one Flash blob. In `_Arc_Unarc` the `CP 0x17` → `26E0` reject sits on the **B≠0 (in-Flash)
+  branch**, immediately before the unarchive worker `61F4` — so an archived group is not unarchived
+  through `61F4`, and groups are handled by a separate routine that walks the group's member list.
+  That member-walk routine is **not
   identifiable in the current Ghidra DB** — `_Arc_Unarc`'s body past the entry `CALL` is not
   disassembled here (cross-page `CALL` flagged non-returning), and no group-archive function is
   named or xref-reachable. Re-confirming it would need a linear disassembly pass like the one behind §4.

--- a/docs/sub-vat-archive.md
+++ b/docs/sub-vat-archive.md
@@ -18,8 +18,9 @@ Confidence (this doc's shorthand; see [Conventions](conventions.md)): **[C]=conf
 ## 1. The arcInfo workspace and key RAM pointers [C]
 
 The archive engine keeps a 12-byte scratch block, labelled `arcInfo` (`83EEh`) in `ti83plus.inc`,
-plus a saved copy `savedArcInfo` (`8406h`). `_Arc_Unarc`'s reentrant inner mover saves it at
-`page_07:61DC` (`LD HL,83F1 / LD DE,8406 / LD BC,0C / LDIR`); the matching `07:61E8` restore candidate is not a defined function in the current live DB.
+plus a saved copy `savedArcInfo` (`8406h`). `_Arc_Unarc`'s reentrant inner mover at `page_07:61DC`
+copies the **12 bytes starting at `83F1`** (the `vatPtr` field onward, not the whole `83EE` block)
+into `8406` (`LD HL,83F1 / LD DE,8406 / LD BC,0C / LDIR`); the matching `07:61E8` restore candidate is not a defined function in the current live DB.
 
 | Addr | Field (this doc's name) | Meaning |
 |------|-------------------------|---------|
@@ -27,8 +28,8 @@ plus a saved copy `savedArcInfo` (`8406h`). `_Arc_Unarc`'s reentrant inner mover
 | `83EF` | `arcInfo.dataPtr` | 2-byte data address (in Flash window 0x4000–0x7FFF, or RAM) |
 | `83F1` | `arcInfo.vatPtr` | pointer to the **VAT entry's type byte** (the symbol record) |
 | `83F3` | `arcInfo.destPtr` | destination data pointer (RAM target on unarchive) |
-| `83F5` | `arcInfo.dataSize` | element/data byte count (from `_DataSize`) |
-| `83F7` | `arcInfo.size` | total bytes to move |
+| `83F5` | `arcInfo.dataSize` | a header/record-size component (loaded from `BC` after `CALL 0FDE`) |
+| `83F7` | `arcInfo.size` | the variable's data byte count (from `_DataSize`; `614B` does `CALL 1485` → `LD (83F7),DE`) |
 | `83F9` | `arcInfo.sizeFull` | size + header overhead |
 | `8406` | `savedArcInfo` | 12-byte save slot for nested calls |
 
@@ -80,7 +81,7 @@ For an **archived** entry the data address (`addrLSB/MSB`) points into the Flash
 
 ## 3. Store / Recall [C/H]
 
-**Store** `_StoOther` (`38:62A9`) and siblings (`_StoAns/_StoX/_StoY/...` `38:6251–62A3`):
+**Store** `_StoOther` (`38:62A9`) and siblings (`_StoAns`, `_StoX`, `_StoY`, … `38:6251–62A3`):
 - Set OP1 type = 0xFF placeholder (`62A9: LD A,FF / LD (8478),A`), parse the destination name.
 - `5F45` resolves/creates the target symbol; then it copies the value. It dispatches on the
   destination name token (`849B`): list-element store (`0x2A` → bounds-checks via `_ErrDimension`),
@@ -118,7 +119,7 @@ _Arc_Unarc (07:6248):
       (Flash, B≠0) LD A,(HL); CP 0x17 ; Group? ⇒ JP 26E0 reject  [groups archive via a different path]
                    CALL 61F4   ; *** Flash → RAM:  unarchive ***
    6272 (RAM, B==0):  CALL 6107        ; *** RAM → Flash:  archive ***
-  ... type-0x5D (complex-list) special-case via 32A9 / cross_page 37:4288
+  ... name-token-0x5D (list name, `tVarLst`) special-case via 32A9 / cross_page 05:4A6E
   LD A,(83EE); OR A; EI; RET
 ```
 
@@ -141,7 +142,7 @@ RAM copy; `61F4` is the one that carves RAM and copies the data back out of Flas
        LD HL,(83F3) ; LD DE,(83F7) ; CALL _DelMem (1368)  ; release the old RAM copy
        RET
 616C:  reads vatPtr type, AND 0x1F (clean type for the record header),
-       LD HL,(83F7)+(83F5) ; ADC ; JP C,2729 (E_Invalid/E_IllegalNest/E_Bound 0x8F/0x90/0x91)  ; size overflow?
+       LD HL,(83F7)+(83F5) ; ADC ; JP C,2729 (E_Invalid, 0x8F)  ; size overflow?
        reserves a Flash slot via 2FDF(3D:61AF) / 2FF7(3D:62C2)
 ```
 The data is **appended** to the archive Flash (Flash cannot be overwritten in place). The VAT entry's
@@ -174,7 +175,7 @@ marked dead (`0xF0`, reclaimed at the next GC). `3D:6440` shares the page-3D fla
 
 ### 4c. Errors raised on the path [C]
 - `2785: LD A,0x31` → `_JError` = **E_ArchFull (0x31)** "ERR:ARCHIVE FULL" (no room even after GC).
-- `2729: LD A,0x8F/0x90/0x91` → E_Invalid / E_IllegalNest / E_Bound (RAM-side overflow during unarchive).
+- `2729`/`272D`/`2731`: `LD A,0x8F`/`0x90`/`0x91` → E_Invalid / E_IllegalNest / E_Bound. The archive size check (`616C`) takes the `2729` (E_Invalid, `0x8F`) entry on overflow.
 - `26E0`+ is a cluster of local error shims: each loads its code (`0xB2`=E_Variable, `0xB3`=E_Duplicate, `0x81`=E_Overflow, `0x82`=E_DivBy0) into `A` and enters `_JError` — not `_ErrDataType`.
 - Error-name strings live at `07:6CA9`: `ARCHIVED, VERSION, ARCHIVE FULL, VARIABLE, DUPLICATE`.
 
@@ -220,7 +221,7 @@ their `flash_*` names are project-local inferred labels (not WikiTI or `ti83plus
 | `00:2FFD` | `3C:7121` (undefined in live DB) | Flash command dispatcher candidate |
 | `00:32A9` | `05:4A6E` | complex-list special-case helper |
 
-The program-core candidates (`3D:64AA`, `3D:61AF`, `3D:6440`) share this unlock prologue:
+The program-core candidates `3D:64AA` and `3D:6440` share this unlock prologue (`3D:61AF` starts differently — `PUSH AF; PUSH HL; BIT 6,(IY+0x24)`):
 ```z80
 RES 7,(IY+0x24) ; LD A,1 ; DI ; IM 1 ; DI ; OUT (0x14),A ; DI ; CALL FUN_ram_02bf
 ```
@@ -263,13 +264,14 @@ bits — port 2 bit 7 (`probe_hw_model_keep_a` `00:1837`) and port 0x21 low bits
 |------------|-------------------------------------------------------|----------------------------------------------------|-----------|
 | port 2 bit 7 **clear** (1 MB) | `0x15` | `0x1E` | `AND 0x1F` (32 pages) |
 | port 0x21 == 0 (mid) | `0x29` | `0x3E` | `AND 0x3F` (64 pages) |
-| else (2 MB) | `0x69` | `0x7E` | `AND 0x3F` |
+| else (2 MB) | `0x69` | `0x7E` | **no mask** (full 8-bit page; `3D:6745` skips both `AND`s) |
 
 So on a 1 MB TI-84 Plus the user archive occupies roughly raw pages **0x15…0x1E**, and the OS pages it
 into the `0x4000` window **one 16 KB page at a time** for both reading (`_FlashToRam`, masks `0x1F`/`0x3F`
 via the same model check, `3D:6745`) and erasing. `flash_set_sector_cnt` (`3D:727D`) loads
-`(base+1)` into the sector counter `0x82A3`; the erase routine `flash_erase_wait` (`3D:5ED3` →
-`3D:5EE3`) pages each sector to `0x4000` and issues the chip erase command via `RST 0x28`, decrementing
+`(base+1)` into the sector counter `0x82A3`; the erase routine `flash_erase_wait` (`3D:5ED3`, whose
+loop jumps to `3D:5EF1` — `3D:5EE3` is the unrelated `_FindApp`) pages each sector to `0x4000` and
+issues the chip erase command via `RST 0x28`, decrementing
 `0x82A3` down toward the base page. The underlying Am29F-class chip uses **64 KB physical sectors
 (= 4 × 16 KB OS pages)**; the OS walks/erases at 16 KB page granularity. [64 KB physical-sector figure: I]
 


### PR DESCRIPTION
Continues the ROM-grounded accuracy audit (part 1 was #28, merged). Each claim is checked against Ghidra disassembly, raw `tools/rom.bin` / retail-segment bytes, and the `ti83plus.inc` / name tables, with cross-model review (codex + psi + Claude) until reviewers report no remaining issues.

## Articles corrected this part

- **08 — Display / LCD:** `_GrBufClr` clears the buffer (only `_GrBufCpy` blits); `_ClrLCDFull` writes 768 bytes; alt large fonts dispatch via page-3B hook routines (selector `A=0x01`/`0x76`), not "page 1"/"page 0x36" fonts; `_DispHL` scratch is the OP1 area; notation (`07:45FF`, page-0 `ram:`).
- **09 — Keyboard & link:** key codes are 1-byte (~255 distinct, not "642"); `kbd_reset_port` listing fixed (`0480`=`PUSH AF`, 84+ link gate); scan code is `group×8 + L` with `L` 1-based; matrix group 0 is the arrow keys (GRAPH is group 6); `_GetKey` makes alpha **one-shot** via `ram:04BF`; fabricated `_CmdLoad` replaced with the real `_SendCmd`.

The cross-model trio repeatedly caught errors a single reviewer missed (e.g. psi caught the alt-font page misread and the GRAPH-group error; codex caught `_GrBufClr` and the `_GetKey` alpha-clear; Claude caught the contrast false-positive).

Remaining articles (`sub-*` deep-dives, `bcall-index`, `token-tables`, `00`, `99`) are still in progress.