### PR TITLE
Fix chapter title/sidebar number mismatch

### DIFF
--- a/docs/01-memory-map.md
+++ b/docs/01-memory-map.md
@@ -1,4 +1,4 @@
-# 01 — Memory map
+# Memory map
 
 The Z80 sees a flat 64 KiB logical space, divided into four 16 KiB slots. Hardware paging (ports 6/7) decides which physical flash page or RAM page is visible in the two middle slots. See [02-paging.md](02-paging.md) for the banking detail and [14-ram-pages.md](14-ram-pages.md) for RAM page `83` and restore rules.
 

--- a/docs/02-paging.md
+++ b/docs/02-paging.md
@@ -1,4 +1,4 @@
-# 02 — Memory paging
+# Memory paging
 
 The Z80's banked 16 KiB slots are windows onto physical memory selected by I/O ports.
 

--- a/docs/03-bcall-mechanism.md
+++ b/docs/03-bcall-mechanism.md
@@ -1,4 +1,4 @@
-# 03 — The bcall system-call mechanism
+# The bcall system-call mechanism
 
 This is the heart of how the OS spans 1 MiB with a 64 KiB CPU. A routine on any page calls a routine on any other page by `bcall` without knowing where it physically lives.
 

--- a/docs/04-interrupts.md
+++ b/docs/04-interrupts.md
@@ -1,4 +1,4 @@
-# 04 — Interrupts (IM1)
+# Interrupts (IM1)
 
 The Z80 runs in interrupt mode 1: every maskable interrupt vectors to `0038h`. There is no vector table — one handler services all sources by polling status ports.
 

--- a/docs/05-variables-vat.md
+++ b/docs/05-variables-vat.md
@@ -1,4 +1,4 @@
-# 05 — Variables & the VAT (Variable Allocation Table)
+# Variables & the VAT (Variable Allocation Table)
 
 > **Deep dive:** [Variables, Archive & Unarchive](sub-vat-archive.md) — Store/Recall, the byte-verified `_FindSym` walk, and archive/unarchive.
 

--- a/docs/06-floating-point.md
+++ b/docs/06-floating-point.md
@@ -1,4 +1,4 @@
-# 06 — Floating-point engine
+# Floating-point engine
 
 > **Deep dive:** [Calculation Engine](sub-calculation.md) — ×, ÷, ^, roots, the transcendentals (sin/cos/ln/eˣ), and number formatting.
 

--- a/docs/07-tokenizer-basic.md
+++ b/docs/07-tokenizer-basic.md
@@ -1,4 +1,4 @@
-# 07 — Tokenizer & TI-BASIC
+# Tokenizer & TI-BASIC
 
 TI-BASIC programs are stored as tokens, not text: every command, function, and variable is a token of 1 or 2 bytes. The OS detokenizes (token→display string) to show a program and tokenizes (keypress/text→token) on entry; the parser walks tokens to execute.
 

--- a/docs/08-display-lcd.md
+++ b/docs/08-display-lcd.md
@@ -1,4 +1,4 @@
-# 08 — Display & LCD
+# Display & LCD
 
 > **Deep dives:** [Graphing](sub-graphing.md) (graph buffer → LCD, transforms) · [Table & Y= Variables](sub-table-yvars.md) (text grid).
 

--- a/docs/09-keyboard-link.md
+++ b/docs/09-keyboard-link.md
@@ -1,4 +1,4 @@
-# 09 — Keyboard & link port
+# Keyboard & link port
 
 > **Deep dive:** [Link / Data Transfer](sub-link-transfer.md) — the silent-link packet protocol and variable send/receive.
 

--- a/docs/10-subsystem-map.md
+++ b/docs/10-subsystem-map.md
@@ -1,4 +1,4 @@
-# 10 — Subsystem map (bcall API surface)
+# Subsystem map (bcall API surface)
 
 This page categorizes the ~600 named bcall entry points (the OS's public API) by subsystem, so the whole OS surface is visible at once. This is the surface area user code and the OS itself program against.
 

--- a/docs/11-boot-contexts-errors.md
+++ b/docs/11-boot-contexts-errors.md
@@ -1,4 +1,4 @@
-# 11 — Boot, contexts, and error handling
+# Boot, contexts, and error handling
 
 Three cross-cutting mechanisms that tie the OS together: how it starts, how it switches "modes" (contexts), and how it aborts on error.
 

--- a/docs/12-memory-management.md
+++ b/docs/12-memory-management.md
@@ -1,4 +1,4 @@
-# 12 — Memory management (RAM heap & Flash archive)
+# Memory management (RAM heap & Flash archive)
 
 How the OS allocates the ~24 KiB of user RAM between variables, temporaries, the FP stack, and the program being run — and how it offloads variables to Flash ("archive").
 

--- a/docs/13-flash-page-map.md
+++ b/docs/13-flash-page-map.md
@@ -1,4 +1,4 @@
-# 13 — Flash page map
+# Flash page map
 
 What lives on each of the 64 physical flash pages (16 KiB each). OS code occupies pages `00–07` and `33–3D`; pages `08–32` are blank in this image; page `3E` is the certificate sector and `3F` the boot page. On a retail unit the upper pages can also carry Flash Apps, but this dump is OS-only — the page scan below reports zero Flash-App headers. The page roles below are characterized by the named bcall routines that resolve to each page (`tools/bcall_targets.txt`) plus function counts; the `0x8xxx` cert/boot/USB bcalls come instead from `ti83plus.inc` and the retail segment files (`bcall_targets.txt` does not carry the `0x8xxx` targets).
 

--- a/docs/14-ram-pages.md
+++ b/docs/14-ram-pages.md
@@ -1,4 +1,4 @@
-# 14 — RAM pages
+# RAM pages
 
 The TI-84 Plus has banked RAM pages behind the Z80's 16 KiB windows. TI-OS normally
 keeps RAM page `81` in `8000-BFFF` and RAM page `80` in `C000-FFFF`, but ROM helpers

--- a/docs/99-open-questions.md
+++ b/docs/99-open-questions.md
@@ -1,4 +1,4 @@
-# 99 — Open questions & roadmap
+# Open questions & roadmap
 
 The structural reverse-engineering is comprehensive (every subsystem mapped, both cross-page mechanisms resolved, full input→parse→eval→display pipeline documented). What remains is depth. Each item below is self-contained for a future session.
 


### PR DESCRIPTION
Each numbered chapter's H1 carried an `NN — ` prefix from its filename (e.g. `11 — Boot, contexts, and error handling`), which clashed with mdbook's sidebar auto-numbering where that same page is chapter 8. This drops the filename-derived prefix from all 15 chapter H1s so the page title matches the sidebar; filenames are unchanged so internal links still resolve.