### PR TITLE
Ignore Ghidra backup lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ tools/roms/
 *.gpr
 *.rep/
 *.lock
+*.lock~
 !flake.lock
 *.ghidra
 


### PR DESCRIPTION
## What changed

- Remove the accidentally tracked empty `ti84.lock~` Ghidra lock backup.
- Ignore future `*.lock~` files alongside existing `*.lock` files.

## Why

Ghidra generated `ti84.lock~`, and the existing `*.lock` rule did not match the trailing `~`, allowing the empty generated file to be committed.

## Impact

Generated Ghidra lock backups will no longer appear as repository changes.

## Validation

- `git diff --check origin/main...HEAD`
- Confirmed `git check-ignore -v --no-index ti84.lock~` matches the new rule.