### PR TITLE
Clarify hardware diagram evidence and assumptions

### DIFF
--- a/docs/bus-timing.md
+++ b/docs/bus-timing.md
@@ -59,7 +59,7 @@ That one byte controls two independent effects:
 - bits 2–7 select the T-states added to each LCD-port instruction;
 - bit 0 enables the Flash bits in port `0x2E`, and bit 1 enables the RAM bits.
 
-![CPU speed selects one delay register; that register controls LCD instruction additions and gates port 2E memory waits, while port 2F controls a separate LCD-ready hold.](images/bus-wait-timing.svg)
+![CPU speed selects one delay register; that register controls LCD instruction additions and gates port 2E memory waits, while port 2F reports a separate LCD busy interval for software to poll.](images/bus-wait-timing.svg)
 
 **Timing model.** The register behavior is [standard], and the diagram's widths are conceptual. OS 2.55MP's register bytes and executed speed values are [confirmed].
 

--- a/docs/clock-timers-power.md
+++ b/docs/clock-timers-power.md
@@ -269,7 +269,7 @@ physical timer edges prevent the nominal calculation from serving as a
 physical measurement. [confirmed] for the constants and control flow;
 [standard] for the timer decode; [hypothesis] for physical cadence.
 
-![The programmed timer path gives a nominal 31.25 kHz ISR and 17.36 tracker updates per second; the upstream 33,333.3 Hz tuning constant and one trace's 4,674 writes per second are separate evidence lanes.](images/badapple-timer-evidence.svg)
+![The programmed timer path gives a nominal 31.25 kHz ISR and 17.36 tracker updates per second; the upstream 33,333.3 Hz tuning constant and one trace's 4,674 writes per interpreted second at 15 MHz are separate evidence lanes.](images/badapple-timer-evidence.svg)
 
 **Cadence evidence.** The top lane combines [confirmed] application bytes with
 the [standard] timer decode. The encoder and trace lanes preserve their source

--- a/docs/execution-protection.md
+++ b/docs/execution-protection.md
@@ -118,7 +118,7 @@ allows page `0x08`, while TilEm denies it. Both deny page `0x09` and page
 but the physical page-`0x08` result remains unmeasured. [standard] for the
 published contract and source comparison; [hypothesis] for hardware.
 
-![TilEm denies Flash pages 08 through 29, while Wabbitemu permits page 08 and denies 09 through 29; both permit the outer ranges.](images/execution-protection-ranges.svg)
+![Emulator models differ: TilEm denies Flash pages 08 through 29, while Wabbitemu permits page 08 and denies 09 through 29; the lower panel also compares their RAM execution predicates.](images/execution-protection-ranges.svg)
 
 **Boot execution ranges.** The written bounds are [confirmed], and the emulator predicates are [standard]. The physical page-`08` boundary remains [hypothesis]. The RAM panel introduces the mode-dependent chunk model detailed below.
 

--- a/docs/flash-memory.md
+++ b/docs/flash-memory.md
@@ -16,9 +16,11 @@ The mechanisms below use several evidence sources. A claim marked [confirmed] co
 | Flash device | Datamath's March 2004 board photograph and Fujitsu `MBM29LV800TA` data sheet | observed package marking, sector geometry, command cycles, DQ status semantics, and rated limits [standard] |
 | Emulator comparison | pinned TilEm, Wabbitemu, MAME, and jsTIfied source | modeled command decode, mutation rules, status reads, timing, and missing ASIC gates [standard] |
 
-![A Flash operation passes software guards, a RAM-resident worker, ASIC command gates, the Flash command state machine, and the physical sector. Execution protection is a separate fetch path.](images/flash-write-layers.svg)
+![A Flash operation depends on caller page and argument guards before a RAM-resident worker, ASIC command gates, the Flash command state machine, and the physical sector. Execution protection is a separate fetch path.](images/flash-write-layers.svg)
 
-**Write-layer schematic.** Bcall guards and RAM-worker execution are [confirmed]. ASIC gate details and the AMD-compatible command state machine are [standard].
+**Write-layer schematic.** Bcall entry guards, remaining caller obligations,
+and RAM-worker execution are [confirmed]. ASIC gate details and the
+AMD-compatible command state machine are [standard].
 
 ## Physical organization
 

--- a/docs/images/badapple-timer-evidence.svg
+++ b/docs/images/badapple-timer-evidence.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="760" viewBox="0 0 1200 760" role="img" aria-labelledby="title desc">
   <title id="title">Bad Apple timer cadence separates register decode, encoder tuning, and trace observation</title>
-  <desc id="desc">Three horizontal evidence lanes distinguish the programmed timer path from two other numbers. The programmed path selects nominal 15 megahertz, divides by 4 through source 82, reloads 120, and yields a nominal 31,250 interrupts per second; dividing by 1,800 gives about 17.36 tracker updates per second. A separate encoder lane shows the upstream 33,333.3 hertz tuning assumption used for note counts and rendering. A trace lane shows about 4,674 port writes per interpreted second from one injected TilEm run and labels it diagnostic rather than physical hardware evidence.</desc>
+  <desc id="desc">Three horizontal evidence lanes distinguish the programmed timer path from two other numbers. The programmed path selects nominal 15 megahertz, divides by 4 through source 82, reloads 120, and yields a nominal 31,250 interrupts per second; dividing by 1,800 gives about 17.36 tracker updates per second. A separate encoder lane shows the upstream 33,333.3 hertz tuning assumption used for note counts and rendering. A trace lane shows about 4,674 port writes per second when trace time is interpreted at 15 megahertz in one injected TilEm run and labels it diagnostic rather than physical hardware evidence.</desc>
   <defs>
     <style>
       .bg{fill:#f8fafc}.panel{fill:#fff;stroke:#94a3b8;stroke-width:2}.title{fill:#0f172a;font:700 30px system-ui,sans-serif}.subtitle{fill:#475569;font:17px system-ui,sans-serif}.lanehead{fill:#0f172a;font:700 22px system-ui,sans-serif}.head{fill:#0f172a;font:700 18px system-ui,sans-serif}.text{fill:#334155;font:16px system-ui,sans-serif}.small{fill:#475569;font:14px system-ui,sans-serif}.mono{fill:#0f172a;font:600 16px ui-monospace,SFMono-Regular,Consolas,monospace}.program{fill:#dcfce7;stroke:#16a34a;stroke-width:2}.register{fill:#ede9fe;stroke:#7c3aed;stroke-width:2}.derived{fill:#dbeafe;stroke:#2563eb;stroke-width:2}.assumption{fill:#fef3c7;stroke:#d97706;stroke-width:2}.trace{fill:#f3e8ff;stroke:#9333ea;stroke-width:2}.warning{fill:#fee2e2;stroke:#dc2626;stroke-width:2}.arrow{stroke:#475569;stroke-width:2.5;fill:none;marker-end:url(#arrow)}.dashed{stroke:#94a3b8;stroke-width:2;stroke-dasharray:7 6;fill:none}.divider{stroke:#cbd5e1;stroke-width:2}
@@ -59,7 +59,8 @@
   <text class="lanehead" x="88" y="603">TilEm trace observation</text>
   <rect class="trace" x="390" y="589" width="220" height="76" rx="10"/>
   <text class="head" x="500" y="618" text-anchor="middle">observed port writes</text>
-  <text class="mono" x="500" y="646" text-anchor="middle">≈ 4,674 / s</text>
+  <text class="mono" x="500" y="640" text-anchor="middle">≈ 4,674 / s</text>
+  <text class="small" x="500" y="660" text-anchor="middle">time interpreted at 15 MHz</text>
   <path class="arrow" d="M610 627 H679"/>
   <rect class="warning" x="680" y="589" width="340" height="76" rx="10"/>
   <text class="head" x="850" y="618" text-anchor="middle">diagnostic run result</text>

--- a/docs/images/bus-wait-timing.svg
+++ b/docs/images/bus-wait-timing.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="780" viewBox="0 0 1200 780" role="img" aria-labelledby="title desc">
   <title id="title">Conceptual timing effects of TI-84 Plus bus-delay registers</title>
-  <desc id="desc">The upper half shows the CPU speed selecting one delay byte from ports 29 through 2C. Its high bits add time to LCD port instructions and its low bits gate Flash and RAM wait bits in port 2E. The lower half contrasts a one T-state Flash opcode wait with the longer LCD-ready hold selected by port 2F.</desc>
+  <desc id="desc">The upper half shows the CPU speed selecting one delay byte from ports 29 through 2C. Its high bits add time to LCD port instructions and its low bits gate Flash and RAM wait bits in port 2E. The lower half contrasts a one T-state Flash opcode wait with the longer LCD busy interval reported by the port 2F ready status.</desc>
   <defs>
     <style>
       .bg{fill:#f8fafc}.panel{fill:#fff;stroke:#94a3b8;stroke-width:2}.title{fill:#0f172a;font:700 30px system-ui,sans-serif}.head{fill:#0f172a;font:700 20px system-ui,sans-serif}.text{fill:#334155;font:16px system-ui,sans-serif}.mono{fill:#0f172a;font:600 16px ui-monospace,SFMono-Regular,Consolas,monospace}.port{fill:#ede9fe;stroke:#7c3aed;stroke-width:2}.lcd{fill:#dbeafe;stroke:#2563eb;stroke-width:2}.flash{fill:#fef3c7;stroke:#d97706;stroke-width:2}.ram{fill:#dcfce7;stroke:#16a34a;stroke-width:2}.arrow{stroke:#475569;stroke-width:2.5;fill:none;marker-end:url(#arrow)}.wave{stroke:#0f172a;stroke-width:3;fill:none}.grid{stroke:#cbd5e1;stroke-width:1}.wait{fill:#fde68a;stroke:#d97706;stroke-width:1.5}.hold{fill:#bfdbfe;stroke:#2563eb;stroke-width:1.5}.ready{stroke:#2563eb;stroke-width:4;fill:none}
@@ -9,7 +9,7 @@
   </defs>
   <rect class="bg" width="1200" height="780" rx="18"/>
   <text class="title" x="60" y="54">Bus timing uses two different delay mechanisms</text>
-  <text class="text" x="60" y="84">Per-access wait states extend a CPU transaction; LCD-ready hold delays when the next transaction may begin.</text>
+  <text class="text" x="60" y="84">Per-access waits extend a CPU transaction; port 2F reports a separate LCD busy interval for software to poll.</text>
 
   <rect class="panel" x="60" y="120" width="1080" height="280" rx="14"/>
   <text class="head" x="600" y="155" text-anchor="middle">Register selection and effects</text>
@@ -47,7 +47,7 @@
     <text class="mono" x="0" y="127">LCD ready</text>
     <path class="ready" d="M150 115 H240 V145 H780 V115 H900"/>
     <rect class="hold" x="240" y="115" width="540" height="38" opacity="0.55"/>
-    <text class="mono" x="510" y="137" text-anchor="middle">port 2F: ready low for 48 + 64f T-states</text>
+    <text class="mono" x="510" y="137" text-anchor="middle">port 2F status: ready low for 48 + 64f T-states</text>
   </g>
   <text class="text" x="90" y="700">Diagram widths are conceptual. The OS mode-1 field f = 3 gives a 240-T-state ready hold.</text>
 </svg>

--- a/docs/images/execution-protection-ranges.svg
+++ b/docs/images/execution-protection-ranges.svg
@@ -8,10 +8,10 @@
   </defs>
   <rect class="bg" width="1200" height="730" rx="18"/>
   <text class="title" x="60" y="54">Execution protection is a fetch predicate over physical addresses</text>
-  <text class="text" x="60" y="84">Boot writes the bounds. Emulator models disagree at one Flash boundary and in RAM repetition.</text>
+  <text class="text" x="60" y="84">These are emulator predicates, not measured hardware behavior; the models disagree at key boundaries.</text>
 
   <rect class="panel" x="60" y="120" width="1080" height="330" rx="14"/>
-  <text class="head" x="90" y="158">Flash pages · boot bounds port 22 = 08h, port 23 = 29h</text>
+  <text class="head" x="90" y="158">Emulator Flash predicates · boot bounds port 22 = 08h, port 23 = 29h</text>
   <g transform="translate(220 195)">
     <text class="head" x="-25" y="38" text-anchor="end">TilEm</text>
     <rect class="allow" x="0" y="0" width="112" height="70" rx="8"/>
@@ -36,7 +36,7 @@
   <text class="text" x="600" y="432" text-anchor="middle">Each strip spans pages 00–3F; widths are proportional to the number of 16 KiB pages.</text>
 
   <rect class="panel" x="60" y="485" width="1080" height="185" rx="14"/>
-  <text class="head" x="90" y="523">RAM chunks · boot bounds port 25 = 10h, port 26 = 20h</text>
+  <text class="head" x="90" y="523">Emulator RAM predicates · boot bounds port 25 = 10h, port 26 = 20h</text>
   <rect class="port" x="90" y="550" width="300" height="82" rx="10"/>
   <text class="mono" x="240" y="580" text-anchor="middle">10h × 400h → lower</text>
   <text class="mono" x="240" y="608" text-anchor="middle">20h × 400h → upper</text>

--- a/docs/images/flash-write-layers.svg
+++ b/docs/images/flash-write-layers.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="780" viewBox="0 0 1200 780" role="img" aria-labelledby="title desc">
   <title id="title">Independent layers involved in a TI-84 Plus Flash write</title>
-  <desc id="desc">A left-to-right path shows software page guards, a RAM-resident worker, the ASIC port 14 command gate and sector override group, the AMD-compatible Flash command state machine, and the physical erase sector. A separate lower lane shows that execution protection controls instruction fetch rather than Flash programming.</desc>
+  <desc id="desc">A left-to-right path distinguishes boot bcall entry-page checks from the caller's remaining span and argument obligations, then shows a RAM-resident worker, the ASIC port 14 command gate and sector override group, the AMD-compatible Flash command state machine, and the physical erase sector. A separate lower lane shows that execution protection controls instruction fetch rather than Flash programming.</desc>
   <defs>
     <style>
       .bg{fill:#f8fafc}.panel{fill:#fff;stroke:#94a3b8;stroke-width:2}.title{fill:#0f172a;font:700 30px system-ui,sans-serif}.head{fill:#0f172a;font:700 20px system-ui,sans-serif}.text{fill:#334155;font:16px system-ui,sans-serif}.mono{fill:#0f172a;font:600 16px ui-monospace,SFMono-Regular,Consolas,monospace}.software{fill:#dbeafe;stroke:#2563eb;stroke-width:2}.asic{fill:#ede9fe;stroke:#7c3aed;stroke-width:2}.chip{fill:#fef3c7;stroke:#d97706;stroke-width:2}.array{fill:#dcfce7;stroke:#16a34a;stroke-width:2}.separate{fill:#fee2e2;stroke:#dc2626;stroke-width:2;stroke-dasharray:8 6}.arrow{stroke:#475569;stroke-width:3;fill:none;marker-end:url(#arrow)}.gate{stroke:#7c3aed;stroke-width:6}.cross{stroke:#dc2626;stroke-width:4}
@@ -16,13 +16,13 @@
     <text class="head" x="545" y="38" text-anchor="middle">Programming and erase path</text>
 
     <rect class="software" x="25" y="75" width="190" height="220" rx="12"/>
-    <text class="head" x="120" y="108" text-anchor="middle">Boot bcall</text>
+    <text class="head" x="120" y="108" text-anchor="middle">Caller + bcall</text>
     <text class="mono" x="120" y="140" text-anchor="middle">_WriteFlash</text>
     <text class="mono" x="120" y="166" text-anchor="middle">_EraseFlash</text>
     <path d="M48 188 H192" stroke="#2563eb" stroke-width="1.5"/>
-    <text class="text" x="120" y="216" text-anchor="middle">page guards</text>
-    <text class="text" x="120" y="242" text-anchor="middle">call-site guard</text>
-    <text class="text" x="120" y="268" text-anchor="middle">argument contract</text>
+    <text class="text" x="120" y="216" text-anchor="middle">entry-page checks</text>
+    <text class="text" x="120" y="242" text-anchor="middle">caller validates span</text>
+    <text class="text" x="120" y="268" text-anchor="middle">address + source</text>
 
     <rect class="software" x="255" y="75" width="190" height="220" rx="12"/>
     <text class="head" x="350" y="108" text-anchor="middle">RAM worker</text>
@@ -35,10 +35,10 @@
     <rect class="asic" x="485" y="75" width="230" height="220" rx="12"/>
     <text class="head" x="600" y="108" text-anchor="middle">ASIC write gates</text>
     <text class="mono" x="600" y="143" text-anchor="middle">port 14 · command lock</text>
-    <text class="text" x="600" y="171" text-anchor="middle">accepts privileged byte prefix</text>
+    <text class="text" x="600" y="171" text-anchor="middle">privileged byte prefix</text>
     <path class="gate" d="M505 198 H695"/>
     <text class="mono" x="600" y="232" text-anchor="middle">port 21 · sector group</text>
-    <text class="text" x="600" y="260" text-anchor="middle">modeled protected-sector override</text>
+    <text class="text" x="600" y="260" text-anchor="middle">modeled sector override</text>
 
     <rect class="chip" x="755" y="75" width="190" height="220" rx="12"/>
     <text class="head" x="850" y="108" text-anchor="middle">Flash chip</text>
@@ -67,6 +67,6 @@
     <path class="cross" d="M560 35 l34 34 m0 -34 l-34 34"/>
     <text class="text" x="620" y="52">These registers gate instruction fetches.</text>
     <text class="text" x="620" y="82">They do not replace the port 14 command lock, sector gate,</text>
-    <text class="text" x="620" y="108">Flash command sequence, or software page checks above.</text>
+    <text class="text" x="620" y="108">Flash command sequence, or caller obligations above.</text>
   </g>
 </svg>

--- a/docs/images/keypad-matrix-scan.svg
+++ b/docs/images/keypad-matrix-scan.svg
@@ -1,15 +1,15 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="760" viewBox="0 0 1200 760" role="img" aria-labelledby="title desc">
   <title id="title">Example scan of the TI-84 Plus active-low keypad matrix</title>
-  <desc id="desc">An eight by eight matrix highlights group 2 and bit 2, the position of the 6 key. Writing mask FB selects group 2. Pressing 6 pulls read bit 2 low, producing FB. The scan-code formula gives hexadecimal 13. The ON key is shown outside the matrix on port 04.</desc>
+  <desc id="desc">A conceptual eight by eight matrix highlights group 2 and bit 1, the wired position of the 3 key, and marks unwired intersections. Writing mask FB selects group 2. Pressing 3 pulls read bit 1 low, producing FD. The scan-code formula gives hexadecimal 12. The ON key is shown outside the matrix on port 04.</desc>
   <defs>
     <style>
-      .bg{fill:#f8fafc}.panel{fill:#fff;stroke:#94a3b8;stroke-width:2}.title{fill:#0f172a;font:700 30px system-ui,sans-serif}.head{fill:#0f172a;font:700 21px system-ui,sans-serif}.text{fill:#334155;font:17px system-ui,sans-serif}.mono{fill:#0f172a;font:600 17px ui-monospace,SFMono-Regular,Consolas,monospace}.grid{stroke:#94a3b8;stroke-width:2}.selected{stroke:#7c3aed;stroke-width:7}.sense{stroke:#2563eb;stroke-width:7}.key{fill:#fef3c7;stroke:#d97706;stroke-width:3}.port{fill:#ede9fe;stroke:#7c3aed;stroke-width:2}.result{fill:#dcfce7;stroke:#16a34a;stroke-width:2}.on{fill:#fee2e2;stroke:#dc2626;stroke-width:2}.arrow{stroke:#475569;stroke-width:2.5;fill:none;marker-end:url(#arrow)}
+      .bg{fill:#f8fafc}.panel{fill:#fff;stroke:#94a3b8;stroke-width:2}.title{fill:#0f172a;font:700 30px system-ui,sans-serif}.head{fill:#0f172a;font:700 21px system-ui,sans-serif}.text{fill:#334155;font:17px system-ui,sans-serif}.mono{fill:#0f172a;font:600 17px ui-monospace,SFMono-Regular,Consolas,monospace}.grid{stroke:#94a3b8;stroke-width:2}.selected{stroke:#7c3aed;stroke-width:7}.sense{stroke:#2563eb;stroke-width:7}.key{fill:#fef3c7;stroke:#d97706;stroke-width:3}.unwired{fill:#f8fafc;stroke:#64748b;stroke-width:2;stroke-dasharray:4 3}.port{fill:#ede9fe;stroke:#7c3aed;stroke-width:2}.result{fill:#dcfce7;stroke:#16a34a;stroke-width:2}.on{fill:#fee2e2;stroke:#dc2626;stroke-width:2}.arrow{stroke:#475569;stroke-width:2.5;fill:none;marker-end:url(#arrow)}
     </style>
     <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L0,6 L9,3 z" fill="#475569"/></marker>
   </defs>
   <rect class="bg" width="1200" height="760" rx="18"/>
-  <text class="title" x="60" y="54">One active-low keypad scan: key 6</text>
-  <text class="text" x="60" y="84">The same port selects one group on write and samples eight sense lines on read.</text>
+  <text class="title" x="60" y="54">One active-low keypad scan: key 3</text>
+  <text class="text" x="60" y="84">Conceptual wiring map: the same port selects a group on write and samples sense lines on read.</text>
 
   <rect class="panel" x="60" y="120" width="710" height="560" rx="14"/>
   <text class="head" x="415" y="158" text-anchor="middle">8 groups × 8 sense bits</text>
@@ -19,9 +19,14 @@
       <path d="M0 0 V385 M70 0 V385 M140 0 V385 M210 0 V385 M280 0 V385 M350 0 V385 M420 0 V385 M490 0 V385"/>
     </g>
     <path class="selected" d="M0 110 H490"/>
-    <path class="sense" d="M140 0 V385"/>
-    <circle class="key" cx="140" cy="110" r="18"/>
-    <text class="head" x="140" y="116" text-anchor="middle">6</text>
+    <path class="sense" d="M70 0 V385"/>
+    <circle class="key" cx="70" cy="110" r="18"/>
+    <text class="head" x="70" y="116" text-anchor="middle">3</text>
+    <g class="unwired">
+      <circle cx="280" cy="0" r="10"/><circle cx="350" cy="0" r="10"/><circle cx="420" cy="0" r="10"/><circle cx="490" cy="0" r="10"/>
+      <circle cx="490" cy="55" r="10"/><circle cx="490" cy="110" r="10"/><circle cx="0" cy="275" r="10"/>
+      <circle cx="0" cy="385" r="10"/><circle cx="70" cy="385" r="10"/><circle cx="140" cy="385" r="10"/><circle cx="210" cy="385" r="10"/><circle cx="280" cy="385" r="10"/><circle cx="350" cy="385" r="10"/><circle cx="420" cy="385" r="10"/><circle cx="490" cy="385" r="10"/>
+    </g>
 
     <g class="mono" text-anchor="end">
       <text x="-18" y="7">g0 · FE</text><text x="-18" y="62">g1 · FD</text><text x="-18" y="117">g2 · FB</text><text x="-18" y="172">g3 · F7</text>
@@ -42,14 +47,14 @@
 
     <rect class="result" y="165" width="325" height="120" rx="12"/>
     <text class="head" x="162" y="199" text-anchor="middle">2. Sample pressed key</text>
-    <text class="mono" x="162" y="232" text-anchor="middle">IN A,(01) → FB</text>
-    <text class="text" x="162" y="261" text-anchor="middle">read bit 2 is low</text>
+    <text class="mono" x="162" y="232" text-anchor="middle">IN A,(01) → FD</text>
+    <text class="text" x="162" y="261" text-anchor="middle">read bit 1 is low</text>
     <path class="arrow" d="M162 285 V327"/>
 
     <rect class="result" y="330" width="325" height="120" rx="12"/>
     <text class="head" x="162" y="364" text-anchor="middle">3. Construct scan code</text>
     <text class="mono" x="162" y="397" text-anchor="middle">8g + b + 1</text>
-    <text class="mono" x="162" y="428" text-anchor="middle">8·2 + 2 + 1 = 13h</text>
+    <text class="mono" x="162" y="428" text-anchor="middle">8·2 + 1 + 1 = 12h</text>
 
     <rect class="on" y="485" width="325" height="95" rx="12"/>
     <text class="head" x="162" y="518" text-anchor="middle">ON is separate</text>

--- a/docs/images/lcd-addressing.svg
+++ b/docs/images/lcd-addressing.svg
@@ -66,6 +66,7 @@
   <rect class="data" x="800" y="515" width="510" height="85" rx="10"/>
   <text class="mono" x="1055" y="548" text-anchor="middle">data byte b7 b6 b5 b4 b3 b2 b1 b0</text>
   <text class="text" x="1055" y="577" text-anchor="middle">eight adjacent horizontal pixels at the selected (r, c) address</text>
+  <path class="arrow" d="M935 400 V490 H1285 V512"/>
 
   <rect class="panel" x="470" y="665" width="870" height="135" rx="14"/>
   <rect class="note" x="490" y="685" width="260" height="95" rx="10"/>

--- a/docs/images/link-differential-audio.svg
+++ b/docs/images/link-differential-audio.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="720" viewBox="0 0 1200 720" role="img" aria-labelledby="title desc">
   <title id="title">Four link-port writes produce three differential audio states</title>
-  <desc id="desc">Four side-by-side cards show port 00 writes 0 through 3. Write 0 releases both lines high and produces zero differential. Write 1 pulls line 0 low and produces negative differential. Write 2 pulls line 1 low and produces positive differential. Write 3 pulls both lines low and produces zero differential. The diagram describes logical states only, not voltage or load safety.</desc>
+  <desc id="desc">Four side-by-side cards show port 00 writes 0 through 3, assuming the peer also releases both lines. Write 0 releases both lines high and produces zero differential. Write 1 pulls line 0 low and produces negative differential. Write 2 pulls line 1 low and produces positive differential. Write 3 pulls both lines low and produces zero differential. The diagram describes logical states only, not voltage or load safety.</desc>
   <defs>
     <style>
       .bg{fill:#f8fafc}.card{fill:#fff;stroke:#94a3b8;stroke-width:2}.title{fill:#0f172a;font:700 30px system-ui,sans-serif}.subtitle{fill:#475569;font:17px system-ui,sans-serif}.head{fill:#0f172a;font:700 22px system-ui,sans-serif}.text{fill:#334155;font:17px system-ui,sans-serif}.small{fill:#475569;font:15px system-ui,sans-serif}.mono{fill:#0f172a;font:600 17px ui-monospace,SFMono-Regular,Consolas,monospace}.bit{fill:#ede9fe;stroke:#7c3aed;stroke-width:2}.line0{stroke:#dc2626;stroke-width:5;fill:none}.line1{stroke:#2563eb;stroke-width:5;fill:none}.guide{stroke:#cbd5e1;stroke-width:2;stroke-dasharray:6 6}.high{fill:#dcfce7;stroke:#16a34a;stroke-width:2}.low{fill:#fee2e2;stroke:#dc2626;stroke-width:2}.zero{fill:#e2e8f0;stroke:#64748b;stroke-width:2}.positive{fill:#dcfce7;stroke:#16a34a;stroke-width:2}.negative{fill:#fee2e2;stroke:#dc2626;stroke-width:2}.note{fill:#fef3c7;stroke:#d97706;stroke-width:2}
@@ -8,7 +8,7 @@
   </defs>
   <rect class="bg" width="1200" height="720" rx="18"/>
   <text class="title" x="60" y="54">Four writes, three idealized differential states</text>
-  <text class="subtitle" x="60" y="84">A set output bit pulls its line low; a clear bit releases its line high.</text>
+  <text class="subtitle" x="60" y="84">A set bit pulls low; a clear bit releases. High states assume the peer also releases.</text>
 
   <g transform="translate(45 120)">
     <rect class="card" width="255" height="470" rx="14"/>
@@ -80,5 +80,5 @@
 
   <rect class="note" x="150" y="625" width="900" height="58" rx="10"/>
   <text class="text" x="600" y="649" text-anchor="middle">Logical high/low states only — no voltage, impedance, bandwidth, or safe-load claim.</text>
-  <text class="small" x="600" y="672" text-anchor="middle">The open-collector schematic above supplies the electrical model; physical values remain unmeasured.</text>
+  <text class="small" x="600" y="672" text-anchor="middle">Assumes an unopposed local output; peer activity can force a released line low.</text>
 </svg>

--- a/docs/images/link-open-collector.svg
+++ b/docs/images/link-open-collector.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="790" viewBox="0 0 1200 790" role="img" aria-labelledby="title desc">
   <title id="title">Open-collector model of the TI two-wire link port</title>
-  <desc id="desc">Two endpoints share line 0 and line 1. Each line has a pull-up and a low-side sink at either endpoint. A line is high only when both endpoints release it. Port 00 write bits command the local sinks, while read bits report the resulting physical levels.</desc>
+  <desc id="desc">Two endpoints share line 0 and line 1. Each endpoint contributes a pull-up resistor and a low-side sink to each line. A line is high only when both endpoints release it. Port 00 write bits command the local sinks, while read bits report the resulting physical levels.</desc>
   <defs>
     <style>
       .bg{fill:#f8fafc}.panel{fill:#fff;stroke:#94a3b8;stroke-width:2}.title{fill:#0f172a;font:700 30px system-ui,sans-serif}.head{fill:#0f172a;font:700 22px system-ui,sans-serif}.text{fill:#334155;font:17px system-ui,sans-serif}.mono{fill:#0f172a;font:600 17px ui-monospace,SFMono-Regular,Consolas,monospace}.wire0{stroke:#dc2626;stroke-width:5;fill:none}.wire1{stroke:#2563eb;stroke-width:5;fill:none}.thin{stroke:#475569;stroke-width:2.5;fill:none}.sink{fill:#e2e8f0;stroke:#475569;stroke-width:2}.high{fill:#dcfce7;stroke:#16a34a;stroke-width:2}.low{fill:#fee2e2;stroke:#dc2626;stroke-width:2}.port{fill:#ede9fe;stroke:#7c3aed;stroke-width:2}.note{fill:#fef3c7;stroke:#d97706;stroke-width:1.5}
     </style>
   </defs>
   <rect class="bg" width="1200" height="790" rx="18"/>
-  <text class="title" x="60" y="54">Two bidirectional lines: release high, pull low</text>
+  <text class="title" x="60" y="54">Two bidirectional lines: release or pull low</text>
   <text class="text" x="60" y="84">Either endpoint can sink either line. No endpoint actively drives a high level.</text>
 
   <rect class="panel" x="60" y="120" width="1080" height="500" rx="14"/>
@@ -15,11 +15,12 @@
   <text class="head" x="1015" y="158" text-anchor="middle">Calculator B / peer</text>
 
   <g transform="translate(0 0)">
-    <text class="mono" x="400" y="215" text-anchor="middle">line 0 · tip · red</text>
+    <text class="mono" x="600" y="215" text-anchor="middle">line 0 · tip · red</text>
     <path class="wire0" d="M250 225 H950"/>
-    <path class="thin" d="M600 225 V170"/>
-    <path class="thin" d="M582 170 H618 M588 160 H612 M594 150 H606"/>
-    <text class="text" x="625" y="166">pull-up</text>
+    <path class="thin" d="M350 225 V205 l-10 -8 l20 -12 l-20 -12 l20 -12 l-10 -8 V135 M330 135 H370"/>
+    <text class="text" x="350" y="128" text-anchor="middle">A pull-up</text>
+    <path class="thin" d="M850 225 V205 l-10 -8 l20 -12 l-20 -12 l20 -12 l-10 -8 V135 M830 135 H870"/>
+    <text class="text" x="850" y="128" text-anchor="middle">B pull-up</text>
 
     <path class="thin" d="M250 225 V270"/><rect class="sink" x="210" y="270" width="80" height="66" rx="8"/>
     <text class="mono" x="250" y="297" text-anchor="middle">sink</text><text class="text" x="250" y="321" text-anchor="middle">write bit 0</text>
@@ -31,11 +32,12 @@
   </g>
 
   <g transform="translate(0 390)">
-    <text class="mono" x="400" y="25" text-anchor="middle">line 1 · ring · white</text>
+    <text class="mono" x="600" y="25" text-anchor="middle">line 1 · ring · white</text>
     <path class="wire1" d="M250 35 H950"/>
-    <path class="thin" d="M600 35 V-20"/>
-    <path class="thin" d="M582 -20 H618 M588 -30 H612 M594 -40 H606"/>
-    <text class="text" x="625" y="-24">pull-up</text>
+    <path class="thin" d="M350 35 V15 l-10 -8 l20 -12 l-20 -12 l20 -12 l-10 -8 V-55 M330 -55 H370"/>
+    <text class="text" x="350" y="-62" text-anchor="middle">A pull-up</text>
+    <path class="thin" d="M850 35 V15 l-10 -8 l20 -12 l-20 -12 l20 -12 l-10 -8 V-55 M830 -55 H870"/>
+    <text class="text" x="850" y="-62" text-anchor="middle">B pull-up</text>
 
     <path class="thin" d="M250 35 V80"/><rect class="sink" x="210" y="80" width="80" height="66" rx="8"/>
     <text class="mono" x="250" y="107" text-anchor="middle">sink</text><text class="text" x="250" y="131" text-anchor="middle">write bit 1</text>

--- a/docs/images/paging-windows.svg
+++ b/docs/images/paging-windows.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="760" viewBox="0 0 1200 760" role="img" aria-labelledby="title desc">
   <title id="title">TI-84 Plus logical memory windows in independent and paired mapping modes</title>
-  <desc id="desc">Two side-by-side stacks show the fixed 0000 to 3FFF window and the three banked 16 KiB windows. Independent mode uses ports 06, 07, and 05 separately. Paired mode uses port 06 for an even and odd page pair and port 07 for window C.</desc>
+  <desc id="desc">Two side-by-side stacks show the fixed 0000 to 3FFF window and the three banked 16 KiB windows. Independent mode uses ports 06, 07, and 05 separately, with ports 0E and 0F supplying high bits for Flash selections. Paired mode uses port 06 and, for Flash, port 0E for an even and odd page pair; port 07 and, for Flash, port 0F select window C.</desc>
   <defs>
     <style>
       .bg{fill:#f8fafc}.panel{fill:#fff;stroke:#94a3b8;stroke-width:2}.head{fill:#0f172a}.sub{fill:#334155}.label{fill:#0f172a;font:600 20px system-ui,sans-serif}.small{fill:#334155;font:16px system-ui,sans-serif}.mono{fill:#0f172a;font:600 17px ui-monospace,SFMono-Regular,Consolas,monospace}.title{fill:#0f172a;font:700 30px system-ui,sans-serif}.mode{fill:#fff;font:700 22px system-ui,sans-serif}.fixed{fill:#dbeafe;stroke:#2563eb;stroke-width:2}.banked{fill:#f1f5f9;stroke:#475569;stroke-width:2}.ram{fill:#dcfce7;stroke:#16a34a;stroke-width:2}.port{fill:#ede9fe;stroke:#7c3aed;stroke-width:2}.arrow{stroke:#475569;stroke-width:2.5;fill:none;marker-end:url(#arrow)}.dash{stroke-dasharray:7 6}.callout{fill:#f1f5f9;stroke:#64748b;stroke-width:1.5}
@@ -30,7 +30,7 @@
       <text class="small" x="18" y="59">Flash or RAM page</text>
       <rect class="port" x="330" y="8" width="125" height="66" rx="8"/>
       <text class="mono" x="392" y="34" text-anchor="middle">port 06</text>
-      <text class="small" x="392" y="58" text-anchor="middle">+ port 0E</text>
+      <text class="small" x="392" y="58" text-anchor="middle">+ 0E if Flash</text>
       <path class="arrow" d="M330 41 H282"/>
     </g>
     <g transform="translate(28 266)">
@@ -39,7 +39,7 @@
       <text class="small" x="18" y="59">Flash or RAM page</text>
       <rect class="port" x="330" y="8" width="125" height="66" rx="8"/>
       <text class="mono" x="392" y="34" text-anchor="middle">port 07</text>
-      <text class="small" x="392" y="58" text-anchor="middle">+ port 0F</text>
+      <text class="small" x="392" y="58" text-anchor="middle">+ 0F if Flash</text>
       <path class="arrow" d="M330 41 H282"/>
     </g>
     <g transform="translate(28 358)">
@@ -70,9 +70,10 @@
       <rect class="banked" width="280" height="82" rx="8"/>
       <text class="mono" x="18" y="30">4000–7FFF · window A</text>
       <text class="small" x="18" y="59">port 06 page with bit 0 clear</text>
-      <rect class="port" x="330" y="45" width="125" height="82" rx="8"/>
-      <text class="mono" x="392" y="79" text-anchor="middle">port 06</text>
-      <text class="small" x="392" y="105" text-anchor="middle">adjacent pair</text>
+      <rect class="port" x="330" y="36" width="125" height="100" rx="8"/>
+      <text class="mono" x="392" y="67" text-anchor="middle">port 06</text>
+      <text class="small" x="392" y="91" text-anchor="middle">+ 0E if Flash</text>
+      <text class="small" x="392" y="116" text-anchor="middle">adjacent pair</text>
       <path class="arrow" d="M330 86 C305 86 305 41 282 41"/>
     </g>
     <g transform="translate(28 266)">
@@ -85,8 +86,9 @@
       <rect class="banked" width="280" height="82" rx="8"/>
       <text class="mono" x="18" y="30">C000–FFFF · window C</text>
       <text class="small" x="18" y="59">page selected by port 07</text>
-      <rect class="port" x="330" y="16" width="125" height="50" rx="8"/>
-      <text class="mono" x="392" y="47" text-anchor="middle">port 07</text>
+      <rect class="port" x="330" y="8" width="125" height="66" rx="8"/>
+      <text class="mono" x="392" y="34" text-anchor="middle">port 07</text>
+      <text class="small" x="392" y="58" text-anchor="middle">+ 0F if Flash</text>
       <path class="arrow" d="M330 41 H282"/>
     </g>
     <rect class="callout" x="28" y="462" width="454" height="62" rx="8"/>

--- a/docs/keypad-on-hardware.md
+++ b/docs/keypad-on-hardware.md
@@ -42,7 +42,7 @@ The conventional scan-code number `0x29` occupies the unused matrix position at 
 
 Writing port `0x01` selects groups with zero bits. Reading the same port returns one bit per key line, where zero means closed. `0xFF` releases every group, and `0x00` selects all groups. [standard]
 
-![Writing FB selects keypad group 2; pressing 6 pulls sense bit 2 low, so the scanner reads FB and constructs scan code 13 hexadecimal.](images/keypad-matrix-scan.svg)
+![In a conceptual matrix with unwired positions marked, writing FB selects keypad group 2; pressing 3 pulls sense bit 1 low, so the scanner reads FD and constructs scan code 12 hexadecimal.](images/keypad-matrix-scan.svg)
 
 **Worked matrix scan.** The active-low electrical contract is [standard]. The group masks and `8g + b + 1` scan-code construction at `ram:0410`–`0453` are [confirmed].
 

--- a/docs/link-port-hardware.md
+++ b/docs/link-port-hardware.md
@@ -34,7 +34,7 @@ The low two write bits are active-high drive controls. Setting a bit pulls that 
 | `2` | pull line 1 low | `1` |
 | `3` | pull both lines low | `0` |
 
-![Each link line has a pull-up and a low-side sink at either endpoint; the line is high only when both endpoints release it.](images/link-open-collector.svg)
+![Each endpoint contributes a pull-up resistor and a low-side sink to each shared link line; a line is high only when both endpoints release it.](images/link-open-collector.svg)
 
 **Open-collector model.** The electrical contract is [standard]. OS 2.55MP's port values and bit order are [confirmed]; pull-up resistance, thresholds, and rise time remain [hypothesis] until measured.
 
@@ -61,17 +61,18 @@ OS 2.55MP sends a zero bit with write `1` and a one bit with write `2`. That agr
 ### Differential audio output
 
 Software can use the two output controls as a three-level differential source.
-If $V_0$ and $V_1$ denote the logical high/low levels of line 0 and line 1,
+If the peer releases both lines and $V_0$ and $V_1$ denote the resulting
+logical high/low levels of line 0 and line 1,
 the idealized differential signal is $V_0 - V_1$: [standard]
 
 | Port-`0x00` write | Line 0 | Line 1 | Idealized differential state |
 |------------------:|--------|--------|------------------------------|
-| `0` | released/high | released/high | zero |
-| `1` | driven low | released/high | negative |
-| `2` | released/high | driven low | positive |
+| `0` | released/high if unopposed | released/high if unopposed | zero |
+| `1` | driven low | released/high if unopposed | negative |
+| `2` | released/high if unopposed | driven low | positive |
 | `3` | driven low | driven low | zero |
 
-![Port writes 0 and 3 produce two distinct zero-differential states, while writes 1 and 2 produce opposite polarities by pulling one link line low.](images/link-differential-audio.svg)
+![Assuming the peer releases both lines, port writes 0 and 3 produce two distinct zero-differential states, while writes 1 and 2 produce opposite polarities by pulling one link line low.](images/link-differential-audio.svg)
 
 **Differential state map.** The three-level output follows the [standard]
 open-collector model. It shows logical polarity rather than analog voltage or


### PR DESCRIPTION
## Summary
- correct the link-port pull-up schematic and qualify peer-release assumptions
- distinguish bcall checks, caller obligations, emulator models, and interpreted trace timing
- clarify mapper selectors, keypad wiring, LCD transfer flow, and port 2F polling semantics
- improve diagram descriptions and Markdown alt text

Follow-up to #55.

## Validation
- `nix shell nixpkgs#libxml2 -c xmllint --noout docs/images/*.svg`
- `nix build`
- rendered and visually inspected all nine SVG diagrams