### PR TITLE
Harden symbol audit rebuilds

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,15 @@ The pipeline (`build.sh`):
 4. `DeepenPass.java` — flow analysis + name remaining bcall sites
 5. `RamRoutines.java` — mark the page-0 bjump trampoline table (87 cross-page vectors)
 6. `ApplyBjumpTargets.java` — disassemble the hot routines those trampolines point to
-7. `FixInlineBjumps.java` — fix all 355 inline `CALL cross_page_jump` tail-jumps
+7. `FixInlineBjumps.java` — fix the currently disassembled inline `CALL cross_page_jump` tail-jumps
 8. `ParserTable.java` — the page-0x38 parser handler dispatch
 9. `RenameFns.java` — apply the accumulated function names in `names.txt`
 10. `BuildTypes.java` — TI-OS enums, structures, and typed regions
 11. `ApplyLabels.java` — apply reviewed ROM-data and internal-entry labels from `labels.txt`
 12. `ApplyOffsetRefs.java` — render reviewed structure-field references from `poffsets.txt`
-13. `RenameVars.java` — apply reviewed local-variable names from `varnames.txt`
+13. `FixInlineBjumps.java` — repeat the fix-up after seeded code and checked metadata are installed
+14. `ApplyOffsetRefs.java` — restore or verify the reviewed offsets after final flow analysis
+15. `RenameVars.java` — apply reviewed local-variable names from `varnames.txt`
 
 Then open `ti84.gpr` in Ghidra (the GhidraMCP plugin exposes it to Claude over `:8080`).
 
@@ -60,7 +62,7 @@ Then open `ti84.gpr` in Ghidra (the GhidraMCP plugin exposes it to Claude over `
 |--------|-------|
 | Functions | rebuilt from the local ROM by `tools/build.sh` |
 | bcall routines named | 704 total: 621 main-table bcalls + 83 retail boot-table bcalls |
-| bjump sites resolved | 355 inline sites + 87-entry trampoline table |
+| bjump sites modeled | every disassembled inline `CALL cross_page_jump` site; the total includes the 87-entry trampoline table |
 | parser handlers | 84 (page 0x38 dispatch table) |
 | Defined data (strings/floats/typed) | 618 |
 | Flash pages loaded | 64 (1 MiB) |

--- a/docs/bcall-mechanism.md
+++ b/docs/bcall-mechanism.md
@@ -62,11 +62,17 @@ All six match the documented TI-83+/84+ RST assignments — strong cross-confirm
 
 Besides bcalls, the OS calls *its own* cross-page routines via `bjump`: `CALL cross_page_jump` (`= CALL ram:2B09`) followed inline by `.dw addr; .db page`. `cross_page_jump` reads the stacked return address (its caller's, via an `SP`-relative load — it does not `POP` it), fetches the 2-byte target + 1-byte page from the inline descriptor there, rewrites the return frame past those 3 bytes, banks the page (`& 0x3F`), and returns into the target. The target's `RET` then returns to *the bjump's caller*, so it behaves like a call that consumes the 3 inline bytes.
 
-There is a trampoline table in the page-0 address range `ram:3B01-ram:3D0A`: 87 packed 6-byte entries, each a bjump to a hot OS routine on another page (`ram:3D0B` already begins a separate `CALL ram:2B49` table). The static Ghidra DB models it in the page-0/ROM address space; whether the table is copied to RAM at runtime is a hypothesis, not MCP-confirmed. Code invokes a routine by `CALL ram:3Bxx` into the table. `tools/bjumps.txt` lists every entry's `(offset → page:addr)`; `tools/RamRoutines.java` marks the inline `.dw/.db` as data and comments each target.
+There is a trampoline table in the page-0 address range `ram:3B01`–`ram:3D0A`: 87 packed 6-byte entries, each a bjump to a hot OS routine on another page (`ram:3D0B` already begins a separate `CALL ram:2B49` table). The static Ghidra DB models it in the page-0/ROM address space; whether the table is copied to RAM at runtime is a hypothesis, not MCP-confirmed. Code invokes a routine by `CALL ram:3Bxx` into the table. `tools/bjumps.txt` lists every entry's `(offset → page:addr)`; `tools/RamRoutines.java` marks the inline `.dw/.db` as data and comments each target.
 
 Example: `_PutMap`'s glyph blitter is reached via the trampoline at `ram:3B3D → 07:4588`.
 
-**Inline bjumps:** besides this trampoline table, `CALL cross_page_jump; .dw; .db` appears in other packed dispatch tables (e.g. a page-`3D` dispatch table near `ram:2B6B`) and inline within OS routines. Because `cross_page_jump` consumes the 3 inline bytes and tail-jumps (the target returns to the bjump's caller), the bytes after must be data and the call is non-returning. `tools/FixInlineBjumps.java` marks all 355 such sites in the complete local ROM, which substantially improved OS-wide disassembly coverage.
+**Inline bjumps.** Besides this trampoline table, `CALL cross_page_jump; .dw;
+.db` appears in packed dispatch tables and inside OS routines. The target returns
+to the bjump caller, so `cross_page_jump` consumes the three inline descriptor
+bytes as a non-returning tail-jump. `tools/FixInlineBjumps.java` runs before and
+after the scripts that seed parser handlers and reviewed function entries. Each
+pass marks every disassembled inline site, including the 87 trampoline-table
+entries. Raw byte matches outside disassembled code are not counted. [confirmed]
 
 ## Limitations
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -24,7 +24,7 @@ Every non-obvious claim is tagged:
 
 | Flag | Meaning |
 |------|---------|
-| [confirmed] | Directly observed in the disassembly/decompiler of this ROM. |
+| [confirmed] | Directly observed in this ROM's disassembly, decompiler, raw bytes, generated database, or a labeled execution trace. |
 | [standard] | Matches the publicly-documented TI-83+/84+ architecture and is consistent with the disassembly, but not every byte was traced. |
 | [hypothesis] | Inferred / not yet verified — treat with caution. |
 
@@ -36,8 +36,9 @@ Every non-obvious claim is tagged:
 The rebuilt Ghidra project keeps each kind of name in a separate checked registry:
 
 - `tools/names.txt` contains function entries. Its importer disassembles the entry and creates a function.
-- `tools/labels.txt` contains ROM data and internal code-entry labels. Its importer never creates a function.
-- `tools/ram.txt` contains RAM and port symbols, including official SDK equates and carefully named inferred state.
+- `tools/labels.txt` contains ROM data and internal code-entry labels. Rows marked `entry` seed and preserve disassembly without creating an overlapping function.
+- `tools/ram.txt` contains RAM symbols, including official SDK equates and carefully named inferred state.
+- `tools/ports.txt` contains I/O-port symbols.
 - `tools/poffsets.txt` contains reviewed base-plus-offset references. These make an operand such as `mathprintArenaState + 0x0D` render as a structure member without inventing a second global name for the field address.
 
 `tools/ty_regions.txt` applies the C layouts built by `BuildTypes.java`. The prose can therefore use expressions such as `table_value_cache.band[1].value[row]` once it introduces the typed base and its concrete address. A physical boundary, trace target, or byte-level proof still keeps its concrete address. [confirmed]
@@ -48,7 +49,7 @@ Formulas are written in LaTeX and rendered by KaTeX (offline, client-side): `$�
 
 ## How this RE was produced
 
-- The Ghidra database is rebuilt from the ROM by `tools/build.sh` (a 13-stage reproducible pipeline around Ghidra's headless analyzer). It loads all 64 flash pages (page 0 + overlays at `4000`), then resolves routines, applies function and data symbols, and installs the checked C layouts and offset references.
+- The Ghidra database is rebuilt from the ROM by `tools/build.sh` (a 15-stage reproducible pipeline around Ghidra's headless analyzer). It loads all 64 flash pages (page 0 + overlays at `4000`), then resolves routines, applies function and data symbols, and installs the checked C layouts and offset references.
 - **Local ROM trust boundary.** `tools/assemble_local_rom.py --check` validates the exact ignored base-ROM and AppVar hashes without writing output. Its reusable `tools/rom_assembly.py` library decodes each TI variable container, verifies its checksum, type, name, flags, duplicate length fields, internal 16 KiB size, and payload hash, then requires the assembled-ROM hash. This proves which bytes the analysis uses; it does not prove that the files were captured from a physical calculator. The pinned base already contains the `D84PBE1.8Xv` page-`3F` payload byte for byte. Only `D84PBE2.8Xv`, installed at page `2F`, changes the base image (8,615 bytes). [confirmed]
 - **bcall table resolution.** The main jump table page was found by *scoring* all 64 flash pages: for each candidate, count how many of the known bcall IDs produce a valid `(addr, page)` entry. Page 0x3B scored highest for the `0x4xxx` table — more known bcall IDs resolve to a valid `(addr, page)` entry there than on any other page — and is confirmed by the documented RST shortcuts (all six matched) and by every entry resolving and live-confirming once 0x3B is applied. `0x8xxx` bcall IDs index the retail boot table on page `3F`; several USB entries target page `2F`. The local `rom.bin` is assembled from the patched base plus the retail `D84PBE1.8Xv` and `D84PBE2.8Xv` payloads, so `tools/bcalls8x_targets.txt` contains 83 byte-resolved body rows. The resolver rejects these targets when page `3F` has a BootFree prefix.
 - **Decompiler caveats.** Ghidra's Z80 decompiler mis-renders some idioms — `SET b,(IY+d)` flag ops, the `CALL cross_page_jump` (`ram:2B09`) trampolines, and register-passed arguments on banked pages. Where the decompiler is unreliable the notes are grounded in the raw disassembly (and several deep-dives used a small custom Z80 decoder over the ROM to verify addresses byte-exactly).

--- a/docs/floating-point.md
+++ b/docs/floating-point.md
@@ -219,8 +219,8 @@ supplies the base-conversion and trig-reduction constants. [confirmed]
 > accumulator add `fp_add_mantissa` `1cb9`), selector sweeping `00…0F` under the
 > `710A CP 0x0F` bound. On-screen results: `.6931471806` and `2.718281828`.
 
-**Sin/cos** (`_SinCosRad`) uses the same recurrence shape on the range-reduced
-angle. `trig_recurrence_table_a` (`02:7201`) and
+`_SinCosRad` uses the same recurrence shape on the range-reduced angle.
+`trig_recurrence_table_a` (`02:7201`) and
 `trig_recurrence_table_b` (`02:7281`) each contain eight rows with two
 sign/phase variants selected by `OP5.value.type` bit 7. The exact rotation
 identity encoded by each row remains open. [confirmed]

--- a/docs/sub-equation-display.md
+++ b/docs/sub-equation-display.md
@@ -60,7 +60,8 @@ by child record IDs. `eqdisp_find_structural_record` (`34:4ACE`) walks the
 structural region, and `eqdisp_find_leaf_record` (`34:4A83`) walks the leaf
 region. `eqdisp_substitute_active_leaf` (`34:4AAF`) substitutes the active
 gap-buffer payload when the leaf pointer equals
-`mathprintArenaState.active_leaf`. The record graph therefore preserves
+`mathprintArenaState.active_leaf` at `0x8DC2` (base `mathprintArenaState` at
+`0x8DAF`). The record graph therefore preserves
 the editable equation tree before evaluation; page `39` row and cell state is
 the transient layout view of that live equation. [confirmed]
 
@@ -239,7 +240,8 @@ bytes, four child slots, and 28 record bytes. Type `0x2B` derives all three
 values from its matrix element count at `33:4F42`–`33:4F6C`. [confirmed]
 
 `34:4869` passes that workspace request to the capacity gate at
-`34:4B7C`. `34:4B86` starts with the word at `0x8DB1`. When
+`34:4B7C`. `eqdisp_capacity_remaining` (`34:4B86`) starts with the word at
+`0x8DB1`. When
 `(IY+2Dh).0` is clear, it subtracts the conditional reserve at `0x8DF8`; when
 the bit is set, it skips that subtraction. It then subtracts the record tail
 at `0x8DBE`. Each subtraction follows `OR A`, so it starts with carry clear and

--- a/docs/sub-link-transfer.md
+++ b/docs/sub-link-transfer.md
@@ -359,11 +359,12 @@ link_xfer_op (3C:4DD2):
   RES 1,(IY+0x24) ; FUN_ram_2800 (restore) ; JP 4F3E (cleanup)
 ```
 
-### 5a. Resolve the variable for sending — `4763` [confirmed]
+### 5a. Resolve the variable for sending — `lnk_resolve_var` [confirmed]
 
-`4763` reads the var-header type byte at `867F` and branches by class. For
-graph/equation types (`0x0F‥0x14`) it uses a cross-page helper. Otherwise
-`47AB` calls `_CkOP1Real`, checks the size, then calls `_ChkFindSym` (`0E60`)
+`lnk_resolve_var` (`3C:4763`) reads the var-header type byte at `0x867F` and
+branches by class. For graph/equation types (`0x0F`–`0x14`) it uses a
+cross-page helper. Otherwise `3C:47AB` calls `_CkOP1Real`, checks the size,
+then calls `_ChkFindSym` (`ram:0E60`)
 to locate the VAT entry. An archived variable routes through the Flash path,
 where `_Chk_Batt_Low` saves `arcInfo.size` at `0x83F7`. `_SetupPagedPtr`
 supplies the data pointer, page, and length inside the DATA sender.

--- a/docs/sub-statistics.md
+++ b/docs/sub-statistics.md
@@ -86,8 +86,8 @@ only `F2`–`FF`, §3). They fill the `PStat…SStat`/`anovaf_vars` block above 
 `PStat`/`ZStat`-writing routine appears among the page-0x3A `stat_*` symbols (all of which are
 the `_OneVar` accumulate/variance/median/regression engine), confirming the tests live in their
 own command handlers reached from the parser's command dispatch, separate from the STAT-CALC
-engine documented here. The exact per-test handler addresses are not exposed as named routines
-in this DB; those per-test handler addresses are [hypothesis]. [confirmed]
+engine documented here. The exact per-test handler addresses are not exposed as
+named routines in this database and remain [hypothesis].
 
 A scratch byte `stat_calc_command` (`0x8A36`, immediately below `statVars`) holds the stat-command
 discriminator (the model index, set from the command token — see §3) for the

--- a/docs/sub-tibasic-programming.md
+++ b/docs/sub-tibasic-programming.md
@@ -234,13 +234,13 @@ pointers have been populated:
 
 | RAM state | Address | Role in the private parser frame |
 |-----------|---------|----------------------------------|
-| `TIBasicParserState.basic_prog` | `9652` | current OP1-style program/object name |
-| `TIBasicParserState.basic_start` | `965B` | first token byte after the stored program size word |
-| `TIBasicParserState.next_parse_byte` | `965D` | current parser cursor |
-| `TIBasicParserState.basic_end` | `965F` | parser end pointer |
-| `TIBasicParserState.num_arguments` | `9661` | argument count/state byte used by parser helpers |
-| `chkDelPtr3` / `chkDelPtr4` | `981C` / `981E` | temporary VAT/data pointers used during name and object setup |
-| `FPS` / `OPS` / `pTemp` / `progPtr` | `9824` / `9828` / `982E` / `9830` | live FP/temp/program storage bounds |
+| `TIBasicParserState.basic_prog` | `0x9652` | current OP1-style program/object name |
+| `TIBasicParserState.basic_start` | `0x965B` | first token byte after the stored program size word |
+| `TIBasicParserState.next_parse_byte` | `0x965D` | current parser cursor |
+| `TIBasicParserState.basic_end` | `0x965F` | parser end pointer |
+| `TIBasicParserState.num_arguments` | `0x9661` | argument count/state byte used by parser helpers |
+| `chkDelPtr3` / `chkDelPtr4` | `0x981C` / `0x981E` | temporary VAT/data pointers used during name and object setup |
+| `FPS` / `OPS` / `pTemp` / `progPtr` | `0x9824` / `0x9828` / `0x982E` / `0x9830` | live FP/temp/program storage bounds |
 
 There is no local variable frame for BASIC programs. A subprogram that uses `A`
 modifies the caller's `A`. For reusable routines, document which variables are

--- a/docs/sub-vat-archive.md
+++ b/docs/sub-vat-archive.md
@@ -42,15 +42,15 @@ byte-confirmed in the disassembly. [hypothesis]
 
 | Addr | Field | Meaning |
 |------|-------------------------|---------|
-| `83EE` | `arcInfo.page`  | page byte of the data (Flash page if archived; RAM marker otherwise) |
-| `83EF` | `arcInfo.data_ptr` | 2-byte data address (in Flash window 0x4000–`0x7FFF`, or RAM) |
-| `83F1` | `arcInfo.vat_ptr` | pointer to the VAT entry's type byte (the symbol record) |
-| `83F3` | `arcInfo.dest_ptr` | destination data pointer (RAM target on unarchive) |
-| `83F5` | `arcInfo.data_size` | a header/record-size component (loaded from `BC` after `CALL 0FDE`) |
-| `83F7` | `arcInfo.size` | the variable's data byte count (from `_DataSize`; `614B` does `CALL 1485` → `LD (83F7),DE`) |
-| `83F9` | `arcInfo.size_full` | size + header overhead |
-| `83FB` | `arcInfo.unknown_tail` | two bytes included in the saved tail; semantics unresolved |
-| `8406` | `savedArcInfo` | 12-byte save slot for `arcInfo.vat_ptr` through `unknown_tail[1]` |
+| `0x83EE` | `arcInfo.page`  | page byte of the data (Flash page if archived; RAM marker otherwise) |
+| `0x83EF` | `arcInfo.data_ptr` | 2-byte data address (in Flash window `0x4000`–`0x7FFF`, or RAM) |
+| `0x83F1` | `arcInfo.vat_ptr` | pointer to the VAT entry's type byte (the symbol record) |
+| `0x83F3` | `arcInfo.dest_ptr` | destination data pointer (RAM target on unarchive) |
+| `0x83F5` | `arcInfo.data_size` | a header/record-size component (loaded from `BC` after `CALL ram:0FDE`) |
+| `0x83F7` | `arcInfo.size` | the variable's data byte count (from `_DataSize`; `07:614B` does `CALL ram:1485` → `LD (83F7),DE`) |
+| `0x83F9` | `arcInfo.size_full` | size + header overhead |
+| `0x83FB` | `arcInfo.unknown_tail` | two bytes included in the saved tail; semantics unresolved |
+| `0x8406` | `savedArcInfo` | 12-byte save slot for `arcInfo.vat_ptr` through `unknown_tail[1]` |
 
 RAM-heap pointers used by the mem checks (cluster at `0x9820`–`0x983A`, confirmed in `.inc`):
 `FPS=9824`, `OPBase=9826`, `OPS=9828` (top of the upward data heap), `pTemp=982E`,

--- a/tools/ApplyLabels.java
+++ b/tools/ApplyLabels.java
@@ -4,7 +4,7 @@ import ghidra.program.model.symbol.*;
 import java.nio.file.*;
 
 // Apply non-function ROM and RAM labels from tools/labels.txt.
-// Line format: <space>:<addrhex> <tab> <name> [<tab> primary|alias]
+// Line format: <space>:<addrhex> <tab> <name> [<tab> primary|alias|entry]
 public class ApplyLabels extends GhidraScript {
     private Address parseLocation(AddressFactory factory, String text) {
         String[] fields = text.split(":", 2);
@@ -41,17 +41,28 @@ public class ApplyLabels extends GhidraScript {
             }
             String name = fields[1];
             if (fields.length == 3 &&
-                    !fields[2].equals("primary") && !fields[2].equals("alias")) {
+                    !fields[2].equals("primary") &&
+                    !fields[2].equals("alias") &&
+                    !fields[2].equals("entry")) {
                 throw new IllegalArgumentException("invalid label mode: " + fields[2]);
             }
-            boolean primary = fields.length < 3 || fields[2].equals("primary");
+            boolean entry = fields.length == 3 && fields[2].equals("entry");
+            boolean primary = fields.length < 3 || !fields[2].equals("alias");
             Symbol existing = existingSymbol(symbols, address, name);
             if (existing != null) {
                 if (primary && !existing.isPrimary()) existing.setPrimary();
-                continue;
+            } else {
+                createLabel(address, name, primary);
+                applied++;
             }
-            createLabel(address, name, primary);
-            applied++;
+            if (entry) {
+                if (getInstructionAt(address) == null && !disassemble(address)) {
+                    throw new IllegalArgumentException(
+                        "could not disassemble internal entry: " + fields[0]
+                    );
+                }
+                symbols.addExternalEntryPoint(address);
+            }
         }
         println("Applied non-function labels: " + applied);
     }

--- a/tools/ApplyOffsetRefs.java
+++ b/tools/ApplyOffsetRefs.java
@@ -5,7 +5,7 @@ import ghidra.program.model.scalar.Scalar;
 import ghidra.program.model.symbol.*;
 import java.nio.file.*;
 
-// Apply reviewed base-plus-offset references from tools/poffsets.txt.
+// Apply or verify reviewed base-plus-offset references from tools/poffsets.txt.
 // Line format: <from-space>:<addr> <tab> <operand> <tab>
 //              <base-space>:<addr> <tab> <offset-hex>
 public class ApplyOffsetRefs extends GhidraScript {
@@ -22,6 +22,7 @@ public class ApplyOffsetRefs extends GhidraScript {
         AddressFactory factory = currentProgram.getAddressFactory();
         ReferenceManager references = currentProgram.getReferenceManager();
         int applied = 0;
+        int verified = 0;
         for (String raw : Files.readAllLines(Paths.get(dir + "/poffsets.txt"))) {
             String line = raw.trim();
             if (line.isEmpty() || line.startsWith("#")) continue;
@@ -34,16 +35,42 @@ public class ApplyOffsetRefs extends GhidraScript {
             if (from == null || base == null) {
                 throw new IllegalArgumentException("unknown poffset address: " + raw);
             }
+            if (!fields[1].matches("[0-9]+") ||
+                    !fields[3].matches("[0-9A-Fa-f]{4}")) {
+                throw new IllegalArgumentException("invalid poffset number: " + raw);
+            }
             int operand = Integer.parseInt(fields[1]);
             long offset = Long.parseLong(fields[3], 16);
+            Address expected = base.add(offset);
+            OffsetReference existing = null;
+            int offsetReferences = 0;
+            for (Reference old : references.getReferencesFrom(from)) {
+                if (old.getOperandIndex() != operand || !old.isOffsetReference()) continue;
+                offsetReferences++;
+                OffsetReference candidate = (OffsetReference) old;
+                if (candidate.getBaseAddress().equals(base) &&
+                        candidate.getOffset() == offset &&
+                        candidate.getToAddress().equals(expected)) {
+                    existing = candidate;
+                }
+            }
+            if (offsetReferences > 1) {
+                throw new IllegalArgumentException(
+                    "duplicate poffset references: " + fields[0] + " op " + operand
+                );
+            }
+            if (existing != null) {
+                references.setPrimary(existing, true);
+                verified++;
+                continue;
+            }
+
             Instruction instruction = getInstructionAt(from);
-            if (instruction == null || operand >= instruction.getNumOperands()) {
+            if (instruction == null || operand < 0 || operand >= instruction.getNumOperands()) {
                 throw new IllegalArgumentException(
                     "invalid poffset source operand: " + fields[0] + " op " + operand
                 );
             }
-
-            Address expected = base.add(offset);
             Reference matched = null;
             int memoryReferences = 0;
             for (Reference old : references.getReferencesFrom(from)) {
@@ -87,6 +114,7 @@ public class ApplyOffsetRefs extends GhidraScript {
             references.setPrimary(reference, true);
             applied++;
         }
-        println("Applied offset references: " + applied);
+        println("Applied offset references: " + applied +
+            "; verified existing: " + verified);
     }
 }

--- a/tools/BuildTypes.java
+++ b/tools/BuildTypes.java
@@ -293,7 +293,7 @@ public class BuildTypes extends GhidraScript {
             String line = raw.trim();
             if (line.isEmpty() || line.startsWith("#")) continue;
             String[] p = line.split("\\t");
-            if (p.length < 2)
+            if (p.length < 2 || p.length > 4)
                 throw new IllegalArgumentException(
                     "ty_regions.txt:" + lineNumber + ": malformed row: " + raw
                 );

--- a/tools/bcall_targets.txt
+++ b/tools/bcall_targets.txt
@@ -608,7 +608,7 @@ _StopTimer	5278	5F42	33
 _WaitTimer	527B	5EA4	33
 _CheckTimer	527E	5F16	33
 _CheckTimerRestart	5281	5F27	33
-grc_4611	52FF	4611	37
+_DispAppRestrictions	52FF	4611	37
 app_5de7	5326	5DE7	3D
 fpx_7dfe	5338	7DFE	02
 fpx_7d9d	533B	7D9D	02

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -29,6 +29,8 @@ fi
 
 python3 "$T/resolve_bcalls.py"          # regenerate bcall_targets.txt (page&0x3F)
 rm -rf "$PROJ/$NAME.gpr" "$PROJ/$NAME.rep"
+GHIDRA_BUILD_LOG="$(mktemp -t ti84-ghidra-build.XXXXXX)"
+trap 'rm -f "$GHIDRA_BUILD_LOG"' EXIT
 "$ANALYZE_HEADLESS" "$PROJ" "$NAME" \
   -import "$T/ti84_page00.bin" -processor z80:LE:16:default \
   -loader BinaryLoader -loader-baseAddr 0x0000 \
@@ -44,7 +46,13 @@ rm -rf "$PROJ/$NAME.gpr" "$PROJ/$NAME.rep"
   -postScript BuildTypes.java "$T" \
   -postScript ApplyLabels.java "$T" \
   -postScript ApplyOffsetRefs.java "$T" \
-  -postScript RenameVars.java "$T"
+  -postScript FixInlineBjumps.java "$T" \
+  -postScript ApplyOffsetRefs.java "$T" \
+  -postScript RenameVars.java "$T" 2>&1 | tee "$GHIDRA_BUILD_LOG"
+if grep -q "REPORT SCRIPT ERROR" "$GHIDRA_BUILD_LOG"; then
+  echo "Ghidra post-script failure; see output above" >&2
+  exit 1
+fi
 echo "Build complete: $PROJ/$NAME.gpr"
 # Pipeline: 64-page load + symbols/floats/bcall-fixup (BuildTI84Full)
 #  -> name 621 bcall routines at real (page,addr) (ApplyBcalls)
@@ -52,4 +60,6 @@ echo "Build complete: $PROJ/$NAME.gpr"
 #  -> apply accumulated manual function names (RenameFns)
 #  -> TI-OS enums/structs/typed regions (BuildTypes)
 #  -> apply non-function symbols and reviewed base+offset references
+#  -> repeat inline-bjump fix-up after seeded entry points
+#  -> restore or verify the reviewed offset references after final flow analysis
 #  -> apply decompiler variable names from varnames.txt (RenameVars)

--- a/tools/dump-mathprint-layout.py
+++ b/tools/dump-mathprint-layout.py
@@ -2548,7 +2548,7 @@ DRAW_PRIMITIVE_BCALLS = [
 ]
 
 DRAW_PRIMITIVE_GHIDRA_RST28_SITES = [
-    (0x4AC9, 0x52FF, "grc_4611", "eqdisp_dispatch_token", "disabled-feature/message helper"),
+    (0x4AC9, 0x52FF, "_DispAppRestrictions", "eqdisp_dispatch_token", "disabled-feature/message helper"),
     (0x4D61, 0x48D9, "unknown_48d9", "_DispMenuTitle", "menu-title display helper"),
     (0x4EE6, 0x450D, "_PutPSB", "eqdisp_emit_glyph", "generic string/cell display"),
     (0x4EEF, 0x51E5, "scr_4619", "eqdisp_emit_glyph", "display/screen helper after cell fallback"),
@@ -9462,13 +9462,13 @@ def dump_square_marker_flow(rom):
         status = "ok" if actual == expected else "MISMATCH"
         print(f"  {page:02X}:{addr:04X}: {status} {actual.hex().upper()}  {note}")
 
-    print("\n_grc_4611 (bcall 52FF) inline call sites")
+    print("\n_DispAppRestrictions (bcall 52FF) inline call sites")
     pattern = bytes.fromhex("efff52")
     hits = find_pattern_locations(rom, pattern)
     for page, addr in hits:
         print(f"  {page:02X}:{addr:04X}")
 
-    print("\npage-37 disabled-feature messages selected by grc_4611")
+    print("\npage-37 disabled-feature messages selected by _DispAppRestrictions")
     for action, addr, selector in (
         (0x05, 0x4B07, 0x9A),
         (0x06, 0x4B23, 0x9C),

--- a/tools/labels.txt
+++ b/tools/labels.txt
@@ -1,5 +1,5 @@
 # Reviewed non-function symbols. Function entries belong in names.txt.
-# Format: <space>:<addr_hex> <TAB> <name> [<TAB> primary|alias]
+# Format: <space>:<addr_hex> <TAB> <name> [<TAB> primary|alias|entry]
 
 # Token and parser dispatch tables.
 ram:1ff6	two_byte_token_lead_table
@@ -21,16 +21,17 @@ page_39:5e45	eqdisp_handler_table
 page_07:45ff	large_font_glyph_table
 
 # MathPrint internal entries whose overlapping flow prevents separate functions.
-page_34:4900	eqdisp_allocate_record
-page_34:4a83	eqdisp_find_leaf_record
-page_34:4aaf	eqdisp_substitute_active_leaf
-page_34:6ccd	eqdisp_resolve_child
-page_34:58a0	eqdisp_insert_structural_marker
-page_34:5da6	eqdisp_draw_hline_clipped
-page_34:6143	eqdisp_draw_marker_primitive
-page_34:62d0	eqdisp_draw_radical_hook
-page_34:636c	eqdisp_render_child1
-page_34:660a	eqdisp_render_leaf_program
+page_34:4900	eqdisp_allocate_record	entry
+page_34:4a83	eqdisp_find_leaf_record	entry
+page_34:4aaf	eqdisp_substitute_active_leaf	entry
+page_34:4b86	eqdisp_capacity_remaining	entry
+page_34:6ccd	eqdisp_resolve_child	entry
+page_34:58a0	eqdisp_insert_structural_marker	entry
+page_34:5da6	eqdisp_draw_hline_clipped	entry
+page_34:6143	eqdisp_draw_marker_primitive	entry
+page_34:62d0	eqdisp_draw_radical_hook	entry
+page_34:636c	eqdisp_render_child1	entry
+page_34:660a	eqdisp_render_leaf_program	entry
 
 # Floating-point and solver constants.
 page_02:7181	logexp_digit_table

--- a/tools/test_symbol_tables.py
+++ b/tools/test_symbol_tables.py
@@ -13,6 +13,11 @@ ROOT = Path(__file__).resolve().parents[1]
 TOOLS = ROOT / "tools"
 LOCATION = re.compile(r"(?:ram|io|page_[0-9A-Fa-f]{2}):[0-9A-Fa-f]{1,4}\Z")
 RAM_LOCATION = re.compile(r"[0-9A-Fa-f]{1,4}\Z")
+PORT_LOCATION = re.compile(r"[0-9A-Fa-f]{1,2}\Z")
+HEX_WORD = re.compile(r"[0-9A-Fa-f]{4}\Z")
+HEX_OFFSET = re.compile(r"[0-9A-Fa-f]{4}\Z")
+HEX_PAGE = re.compile(r"[0-9A-Fa-f]{2}\Z")
+DECIMAL = re.compile(r"[0-9]+\Z")
 SYMBOL = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
 TYPE_SIZES = {
     "byte": 1,
@@ -57,31 +62,88 @@ def tab_rows(name: str) -> list[tuple[int, list[str]]]:
     return result
 
 
-def canonical_location(text: str) -> str:
+def canonical_location(text: str, default_space: str = "ram") -> str:
     if ":" in text:
         space, address = text.split(":", 1)
     else:
-        space, address = "ram", text
+        space, address = default_space, text
     return f"{space.lower()}:{int(address, 16):04x}"
 
 
+def range_is_mapped(space: str, start: int, end: int) -> bool:
+    if space == "ram":
+        return 0 <= start <= end <= 0x3FFF or 0x8000 <= start <= end <= 0xFFFF
+    if space == "io":
+        return 0 <= start <= end <= 0xFF
+    if space.startswith("page_"):
+        page = int(space.removeprefix("page_"), 16)
+        return 1 <= page <= 0x3F and 0x4000 <= start <= end <= 0x7FFF
+    return False
+
+
+def location_is_mapped(location: str) -> bool:
+    space, address_text = location.split(":", 1)
+    address = int(address_text, 16)
+    return range_is_mapped(space, address, address)
+
+
 class SymbolTableTests(unittest.TestCase):
-    def parse_symbols(self, name: str, ram_only: bool = False):
+    def test_address_and_numeric_syntax_boundaries(self):
+        self.assertTrue(location_is_mapped("page_01:4000"))
+        self.assertTrue(location_is_mapped("page_3f:7fff"))
+        self.assertFalse(location_is_mapped("page_00:4000"))
+        self.assertFalse(location_is_mapped("page_40:4000"))
+        self.assertFalse(location_is_mapped("ram:4000"))
+        self.assertFalse(range_is_mapped("ram", 0x3FFF, 0x4000))
+
+        self.assertIsNotNone(HEX_OFFSET.fullmatch("000d"))
+        for invalid in ("d", "0000d", "0xd", "+000d", "000djunk"):
+            self.assertIsNone(HEX_OFFSET.fullmatch(invalid))
+
+    def parse_symbols(
+        self,
+        name: str,
+        raw_space: str | None = None,
+        field_counts: tuple[int, ...] = (2,),
+    ):
         parsed = []
         for line_number, fields in rows(name):
-            self.assertGreaterEqual(len(fields), 2, f"{name}:{line_number}")
+            self.assertIn(len(fields), field_counts, f"{name}:{line_number}")
             location, symbol = fields[:2]
-            pattern = RAM_LOCATION if ram_only else LOCATION
-            self.assertRegex(location, pattern, f"{name}:{line_number}")
-            self.assertRegex(symbol, SYMBOL, f"{name}:{line_number}")
-            parsed.append((canonical_location(location), symbol, line_number))
+            if raw_space == "ram":
+                pattern = RAM_LOCATION
+            elif raw_space == "io":
+                pattern = PORT_LOCATION
+            else:
+                pattern = LOCATION
+            self.assertIsNotNone(pattern.fullmatch(location), f"{name}:{line_number}")
+            self.assertIsNotNone(SYMBOL.fullmatch(symbol), f"{name}:{line_number}")
+            canonical = canonical_location(location, raw_space or "ram")
+            self.assertTrue(location_is_mapped(canonical), f"{name}:{line_number}")
+            parsed.append((canonical, symbol, line_number))
         return parsed
+
+    def parse_bcall_target_locations(self, name: str):
+        locations = set()
+        for line_number, fields in rows(name):
+            self.assertEqual(len(fields), 4, f"{name}:{line_number}")
+            symbol, bcall_id, address, page = fields
+            self.assertIsNotNone(SYMBOL.fullmatch(symbol), f"{name}:{line_number}")
+            self.assertIsNotNone(HEX_WORD.fullmatch(bcall_id), f"{name}:{line_number}")
+            self.assertIsNotNone(HEX_WORD.fullmatch(address), f"{name}:{line_number}")
+            self.assertIsNotNone(HEX_PAGE.fullmatch(page), f"{name}:{line_number}")
+            space = "ram" if int(page, 16) == 0 else f"page_{int(page, 16):02x}"
+            location = canonical_location(f"{space}:{address}")
+            self.assertTrue(location_is_mapped(location), f"{name}:{line_number}")
+            locations.add(location)
+        return locations
 
     def test_symbol_registries_are_unique_and_disjoint(self):
         tables = {
             "names.txt": self.parse_symbols("names.txt"),
-            "labels.txt": self.parse_symbols("labels.txt"),
-            "ram.txt": self.parse_symbols("ram.txt", ram_only=True),
+            "labels.txt": self.parse_symbols("labels.txt", field_counts=(2, 3)),
+            "ram.txt": self.parse_symbols("ram.txt", raw_space="ram"),
+            "ports.txt": self.parse_symbols("ports.txt", raw_space="io"),
         }
         for name, entries in tables.items():
             locations = [entry[0] for entry in entries]
@@ -96,27 +158,50 @@ class SymbolTableTests(unittest.TestCase):
         )
 
         function_locations = {entry[0] for entry in tables["names.txt"]}
+        function_locations |= self.parse_bcall_target_locations("bcall_targets.txt")
+        function_locations |= self.parse_bcall_target_locations("bcalls8x_targets.txt")
         label_locations = {entry[0] for entry in tables["labels.txt"]}
+        ram_locations = {entry[0] for entry in tables["ram.txt"]}
+        port_locations = {entry[0] for entry in tables["ports.txt"]}
         self.assertFalse(
             function_locations & label_locations,
             "a location cannot be both a function and a non-function label",
         )
+        self.assertFalse(
+            function_locations & (ram_locations | port_locations),
+            "a location cannot be both a function and a RAM or port symbol",
+        )
+
+        label_modes = {
+            canonical_location(fields[0]): fields[2] if len(fields) == 3 else "primary"
+            for _, fields in rows("labels.txt")
+        }
+        for location in label_locations & (ram_locations | port_locations):
+            self.assertEqual(
+                label_modes[location], "alias",
+                f"a label overlapping a RAM or port symbol must be an alias: {location}",
+            )
 
     def test_label_modes(self):
         for line_number, fields in rows("labels.txt"):
             self.assertLessEqual(len(fields), 3, f"labels.txt:{line_number}")
             if len(fields) == 3:
-                self.assertIn(fields[2], {"primary", "alias"}, f"labels.txt:{line_number}")
+                self.assertIn(
+                    fields[2], {"primary", "alias", "entry"},
+                    f"labels.txt:{line_number}",
+                )
 
     def test_type_regions_reference_registered_bases(self):
         registered = defaultdict(set)
         for location, symbol, _ in (
-            self.parse_symbols("labels.txt") + self.parse_symbols("ram.txt", True)
+            self.parse_symbols("labels.txt", field_counts=(2, 3))
+            + self.parse_symbols("ram.txt", raw_space="ram")
         ):
             registered[location].add(symbol)
         regions = []
         for line_number, fields in tab_rows("ty_regions.txt"):
             self.assertGreaterEqual(len(fields), 2, f"ty_regions.txt:{line_number}")
+            self.assertLessEqual(len(fields), 4, f"ty_regions.txt:{line_number}")
             location_text, type_name = fields[:2]
             self.assertTrue(LOCATION.fullmatch(location_text) or RAM_LOCATION.fullmatch(location_text),
                             f"ty_regions.txt:{line_number}")
@@ -127,6 +212,7 @@ class SymbolTableTests(unittest.TestCase):
                 count = int(fields[2])
                 self.assertGreater(count, 0, f"ty_regions.txt:{line_number}")
             location = canonical_location(location_text)
+            self.assertTrue(location_is_mapped(location), f"ty_regions.txt:{line_number}")
             if len(fields) >= 4 and fields[3]:
                 self.assertIn(location, registered,
                               f"unregistered typed base at ty_regions.txt:{line_number}")
@@ -136,12 +222,25 @@ class SymbolTableTests(unittest.TestCase):
             space, address_text = location.split(":", 1)
             start = int(address_text, 16)
             end = start + TYPE_SIZES[type_name] * count - 1
-            if space.startswith("page_"):
-                self.assertGreaterEqual(start, 0x4000, f"ty_regions.txt:{line_number}")
-                self.assertLessEqual(end, 0x7FFF, f"ty_regions.txt:{line_number}")
-            else:
-                self.assertLessEqual(end, 0xFFFF, f"ty_regions.txt:{line_number}")
+            self.assertTrue(
+                range_is_mapped(space, start, end), f"ty_regions.txt:{line_number}"
+            )
             regions.append((space, start, end, line_number))
+
+        function_locations = {
+            location for location, _, _ in self.parse_symbols("names.txt")
+        }
+        function_locations |= self.parse_bcall_target_locations("bcall_targets.txt")
+        function_locations |= self.parse_bcall_target_locations("bcalls8x_targets.txt")
+        for location in function_locations:
+            space, address_text = location.split(":", 1)
+            address = int(address_text, 16)
+            for region_space, start, end, line_number in regions:
+                if space == region_space and start <= address <= end:
+                    self.fail(
+                        f"function {location} overlaps typed region at "
+                        f"ty_regions.txt:{line_number}"
+                    )
 
         for index, left in enumerate(regions):
             for right in regions[index + 1:]:
@@ -155,18 +254,43 @@ class SymbolTableTests(unittest.TestCase):
     def test_offset_references_use_registered_bases(self):
         registered = {
             location
-            for name, ram_only in (("labels.txt", False), ("ram.txt", True))
-            for location, _, _ in self.parse_symbols(name, ram_only)
+            for name, raw_space, field_counts in (
+                ("labels.txt", None, (2, 3)),
+                ("ram.txt", "ram", (2,)),
+            )
+            for location, _, _ in self.parse_symbols(name, raw_space, field_counts)
         }
+        typed_regions = {}
+        for _, fields in tab_rows("ty_regions.txt"):
+            location, type_name = fields[:2]
+            count = int(fields[2]) if len(fields) >= 3 and fields[2] else 1
+            typed_regions[canonical_location(location)] = TYPE_SIZES[type_name] * count
+
+        sources = set()
         for line_number, fields in rows("poffsets.txt"):
             self.assertEqual(len(fields), 4, f"poffsets.txt:{line_number}")
             source, operand, base, offset = fields
-            self.assertRegex(source, LOCATION, f"poffsets.txt:{line_number}")
-            self.assertRegex(base, LOCATION, f"poffsets.txt:{line_number}")
+            self.assertIsNotNone(LOCATION.fullmatch(source), f"poffsets.txt:{line_number}")
+            self.assertIsNotNone(LOCATION.fullmatch(base), f"poffsets.txt:{line_number}")
+            self.assertIsNotNone(DECIMAL.fullmatch(operand), f"poffsets.txt:{line_number}")
+            self.assertIsNotNone(HEX_OFFSET.fullmatch(offset), f"poffsets.txt:{line_number}")
             self.assertGreaterEqual(int(operand), 0, f"poffsets.txt:{line_number}")
-            int(offset, 16)
-            self.assertIn(canonical_location(base), registered,
+            canonical_source = canonical_location(source)
+            canonical_base = canonical_location(base)
+            self.assertTrue(location_is_mapped(canonical_source), f"poffsets.txt:{line_number}")
+            self.assertTrue(location_is_mapped(canonical_base), f"poffsets.txt:{line_number}")
+            source_operand = (canonical_source, int(operand))
+            self.assertNotIn(source_operand, sources, f"duplicate poffset source at line {line_number}")
+            sources.add(source_operand)
+
+            offset_value = int(offset, 16)
+            self.assertGreaterEqual(offset_value, 0, f"negative poffset at line {line_number}")
+            self.assertIn(canonical_base, registered,
                           f"unregistered poffset base at poffsets.txt:{line_number}")
+            self.assertIn(canonical_base, typed_regions,
+                          f"untyped poffset base at poffsets.txt:{line_number}")
+            self.assertLess(offset_value, typed_regions[canonical_base],
+                            f"out-of-bounds poffset at poffsets.txt:{line_number}")
 
 
 if __name__ == "__main__":

--- a/tools/ti84plus_extra.inc
+++ b/tools/ti84plus_extra.inc
@@ -1,13 +1,14 @@
 ;==============================================================================
-; ti84plus_extra.inc - symbols mapped by reverse-engineering OS 2.55MP,
-; supplementing the 2001-era ti83plus.inc (which predates many 84+ additions).
+; ti84plus_extra.inc - legacy symbols mapped by reverse-engineering OS 2.55MP.
+; Prefer the official names in the checked 2007 ti83plus.inc when an ID appears
+; in both files.  The inferred aliases remain pending narrative reconciliation.
 ; All names below are RE-INFERRED from behavior, not official TI equates.
 ; They use unprefixed snake_case; address placeholders use these subsystem tags:
 ;   fpx=float/math grf/grc=graph drw=draw scr=screen
 ;   lnk=link app=app-mgmt dsp=display arc=archive mde=mode sta=stat edt=editor
 ;==============================================================================
 
-;--- bcalls present in OS 2.55MP but absent from ti83plus.inc (RE-named) ---
+;--- legacy inferred names for OS 2.55MP bcall bodies ---
 rcl_list_elem_to_op1    .equ 4639h    ; -> 02:47FB  (1 call site)
 rcl_list_elem_b        .equ 463Ch    ; -> 02:47FE  (3 call sites)
 cplx_op_arrange       .equ 4648h    ; -> 02:494F  (2 call sites)
@@ -55,7 +56,6 @@ screen_split         .equ 5227h    ; -> 05:7712  (1 call site)
 grc_454b            .equ 5263h    ; -> 37:454B  (1 call site)
 grc_4556            .equ 5266h    ; -> 37:4556  (1 call site)
 grc_4575            .equ 5269h    ; -> 37:4575  (1 call site)
-grc_4611            .equ 52FFh    ; -> 37:4611  (1 call site)
 app_5de7            .equ 5326h    ; -> 3D:5DE7  (2 call sites)
 fpx_7dfe            .equ 5338h    ; -> 02:7DFE  (1 call site)
 fpx_7d9d            .equ 533Bh    ; -> 02:7D9D  (1 call site)


### PR DESCRIPTION
## Summary

- preserve reviewed internal code entries and restore typed offset references after final flow analysis
- rerun inline-bjump modeling after seeded entries and fail clean builds when Ghidra reports a post-script error
- strengthen registry validation for mapped ranges, ports, bcall targets, typed overlaps, and exact numeric syntax
- reconcile bcall 52FF with the official _DispAppRestrictions name and correct follow-up documentation notation and confidence flags
- replace unstable bjump totals with the actual stage-scoped semantics; each count includes the 87 trampoline entries

## Validation

- nix build
- nix develop -c tools/build.sh
- python3 -m unittest tools.test_symbol_tables tools.test_bcall_tables -v
- python3 -m py_compile tools/dump-mathprint-layout.py tools/resolve_bcalls.py
- git diff --check

The clean Ghidra build modeled 341 sites in the early pass and 403 after reviewed entries were seeded. The final offset pass verified 5 existing references and restored 6 rewritten by flow analysis.